### PR TITLE
Rename user credit type from cacheOut to cashOut

### DIFF
--- a/app/Enums/UserCreditType.php
+++ b/app/Enums/UserCreditType.php
@@ -10,7 +10,7 @@ use Override;
 
 enum UserCreditType: string implements HasColor, HasIcon
 {
-    case CacheOut = 'cacheOut';
+    case CashOut = 'cashOut';
     case UserDonation = 'userDonation';
     case MembershipFees = 'membershipFees';
     case TransferCreditBetweenUsers = 'transferCreditBetweenUsers';
@@ -22,7 +22,7 @@ enum UserCreditType: string implements HasColor, HasIcon
         $trKey = 'sport-event.type_enum_credit_type.';
 
         return [
-            'cacheOut' => __($trKey.self::CacheOut->value),
+            'cashOut' => __($trKey.self::CashOut->value),
             'userDonation' => __($trKey.self::UserDonation->value),
             'membershipFees' => __($trKey.self::MembershipFees->value),
             'transferCreditBetweenUsers' => __($trKey.self::TransferCreditBetweenUsers->value),
@@ -35,7 +35,7 @@ enum UserCreditType: string implements HasColor, HasIcon
     public function getIcon(): string
     {
         return match ($this) {
-            self::CacheOut => 'heroicon-m-arrow-trending-down',
+            self::CashOut => 'heroicon-m-arrow-trending-down',
             self::UserDonation => 'heroicon-m-arrow-trending-up',
             self::MembershipFees => 'heroicon-m-banknotes',
             self::TransferCreditBetweenUsers => 'heroicon-o-truck',
@@ -48,7 +48,7 @@ enum UserCreditType: string implements HasColor, HasIcon
     public function getColor(): string
     {
         return match ($this) {
-            self::CacheOut => 'danger',
+            self::CashOut => 'danger',
             self::UserDonation, self::TransferCreditBetweenUsers => 'success',
             self::MembershipFees, self::InitialDeposit, self::TransportBilling => 'gray',
         };

--- a/app/Services/OrisApiService.php
+++ b/app/Services/OrisApiService.php
@@ -385,7 +385,7 @@ final class OrisApiService
                     //$userCredit->balance = $this->getBalance($userRaceProfile->user, -(float)$entry->getFee());
                     //$userCredit->balance = -(float)$entry->getFee();
                     $userCredit->currency = UserCredit::CURRENCY_CZK;
-                    $userCredit->credit_type = UserCreditType::CacheOut;
+                    $userCredit->credit_type = UserCreditType::CashOut;
                     $userCredit->source = $source;
                     $userCredit->source_user_id = auth()->user()->id;
                     $userCredit->created_at = Carbon::now()->format(AppHelper::MYSQL_DATE_TIME);
@@ -408,7 +408,7 @@ final class OrisApiService
                     $userCredit->sport_event_id = $sportEvent->id;
                     $userCredit->amount = -(float) $entry->Fee;
                     $userCredit->currency = UserCredit::CURRENCY_CZK;
-                    $userCredit->credit_type = UserCreditType::CacheOut;
+                    $userCredit->credit_type = UserCreditType::CashOut;
                     $userCredit->source = UserCredit::SOURCE_USER;
                     $userCredit->source_user_id = auth()->user()->id;
                     $userCredit->created_at = Carbon::now()->format(AppHelper::MYSQL_DATE_TIME);

--- a/database/migrations/2026_03_04_150411_rename_cacheout_to_cashout_in_user_credits.php
+++ b/database/migrations/2026_03_04_150411_rename_cacheout_to_cashout_in_user_credits.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('user_credits')
+            ->where('credit_type', 'cacheOut')
+            ->update(['credit_type' => 'cashOut']);
+    }
+
+    public function down(): void
+    {
+        DB::table('user_credits')
+            ->where('credit_type', 'cashOut')
+            ->update(['credit_type' => 'cacheOut']);
+    }
+};

--- a/lang/cs/sport-event.php
+++ b/lang/cs/sport-event.php
@@ -34,7 +34,7 @@ return [
     ],
 
     'type_enum_credit_type' => [
-        UserCreditType::CacheOut->value => 'Výdaj',
+        UserCreditType::CashOut->value => 'Výdaj',
         UserCreditType::UserDonation->value => 'Mimořádný členský vklad',
         UserCreditType::MembershipFees->value => 'Členské příspěvky',
         UserCreditType::TransferCreditBetweenUsers->value => 'Přesun mezi uživateli',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected cash-out credit identification: Updated all references from "CacheOut" to "CashOut" across the system, including database records, service processing, and language translations for consistent labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->