### PR TITLE
Always use AppHelper::DATE_*_FORMAT consts for formating date/time

### DIFF
--- a/app/Exports/UsersRaceProfileExport.php
+++ b/app/Exports/UsersRaceProfileExport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exports;
 
+use App\Shared\Helpers\AppHelper;
 use App\Filament\Pages\Actions\ExportUserRaceProfileData;
 use App\Models\UserRaceProfile;
 use Illuminate\Database\Eloquent\Builder;
@@ -65,9 +66,9 @@ class UsersRaceProfileExport implements FromQuery, WithHeadings, WithMapping, Sh
             $row->licence_ob,
             $row->licence_lob,
             $row->licence_mtbo,
-            $row->created_at?->format('d.m.Y'),
+            $row->created_at?->format(AppHelper::DATE_FORMAT),
             $row->active ? 'ANO' : 'NE',
-            $row->active_until?->format('d.m.Y'),
+            $row->active_until?->format(AppHelper::DATE_FORMAT),
         ];
     }
 

--- a/app/Filament/Resources/BankTransactions/BankTransactionResource.php
+++ b/app/Filament/Resources/BankTransactions/BankTransactionResource.php
@@ -145,7 +145,7 @@ class BankTransactionResource extends Resource implements HasShieldPermissions
                             return null;
                         }
 
-                        return 'Transakce novější: ' . Carbon::parse($data['date'])->format('d.m.Y');
+                        return 'Transakce novější: ' . Carbon::parse($data['date'])->format(AppHelper::DATE_FORMAT);
                     })->default(now()->subDays(7)),
                 SelectFilter::make('transaction_indicator')
                     ->label('Typ transakce')

--- a/app/Filament/Resources/Pages/PageResource.php
+++ b/app/Filament/Resources/Pages/PageResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\Pages;
 
+use App\Shared\Helpers\AppHelper;
 use App\Enums\AppRoles;
 use App\Filament\Forms\Components\RichEditor\RichContentCustomBlocks\AlertBlock;
 use Filament\Schemas\Schema;
@@ -300,7 +301,7 @@ class PageResource extends Resource implements HasShieldPermissions
                     ->sortable(),
                 TextColumn::make('updated_at')
                     ->label(__('filament-shield::filament-shield.column.updated_at'))
-                    ->dateTime('d. m. Y - H:i')
+                    ->dateTime(AppHelper::DATE_TIME_FORMAT)
                     ->sortable(),
             ])
             ->defaultPaginationPageOption(25)

--- a/app/Filament/Resources/Posts/PostResource.php
+++ b/app/Filament/Resources/Posts/PostResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\Posts;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
@@ -139,7 +140,7 @@ class PostResource extends Resource implements HasShieldPermissions
                     ->falseIcon('heroicon-o-x-circle'),
                 TextColumn::make('updated_at')
                     ->label(__('filament-shield::filament-shield.column.updated_at'))
-                    ->dateTime('d. m. Y - H:i')
+                    ->dateTime(AppHelper::DATE_TIME_FORMAT)
                     ->sortable(),
                 TextColumn::make('private')
                     ->badge()

--- a/app/Filament/Resources/SportEventExports/SportEventExportResource.php
+++ b/app/Filament/Resources/SportEventExports/SportEventExportResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SportEventExports;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
@@ -135,7 +136,7 @@ class SportEventExportResource extends Resource implements HasShieldPermissions
                     ->label('Cesta k souboru'),
                 TextColumn::make('updated_at')
                     ->label(__('filament-shield::filament-shield.column.updated_at'))
-                    ->dateTime('d. m. Y - H:i'),
+                    ->dateTime(AppHelper::DATE_TIME_FORMAT),
             ])
             ->defaultPaginationPageOption(25)
             ->filters([

--- a/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
+++ b/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
@@ -202,7 +202,7 @@ class EntrySportEvent extends Page implements HasForms, HasTable
                 ->searchable(),
             TextColumn::make('created_at')
                 ->label('Vytvořeno')
-                ->dateTime('d. m. Y - H:i')
+                ->dateTime(AppHelper::DATE_TIME_FORMAT)
                 ->searchable()
                 ->sortable(),
         ];

--- a/app/Filament/Resources/SportEvents/RelationManagers/SportEventNewsRelationManager.php
+++ b/app/Filament/Resources/SportEvents/RelationManagers/SportEventNewsRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SportEvents\RelationManagers;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\EditAction;
@@ -47,7 +48,7 @@ class SportEventNewsRelationManager extends RelationManager
                 TextColumn::make('date')
                     ->icon('heroicon-o-calendar')
                     ->label(__('sport-event.event_news.date'))
-                    ->dateTime('d.m.Y H:i')
+                    ->dateTime(AppHelper::DATE_TIME_FORMAT)
                     ->sortable(),
                 TextColumn::make('text')
                     ->label(__('sport-event.event_news.content'))

--- a/app/Filament/Resources/SportEvents/RelationManagers/SportServicesRelationManager.php
+++ b/app/Filament/Resources/SportEvents/RelationManagers/SportServicesRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SportEvents\RelationManagers;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Schemas\Components\Grid;
 use Filament\Actions\ActionGroup;
@@ -69,7 +70,7 @@ class SportServicesRelationManager extends RelationManager
                 TextColumn::make('last_booking_date_time')
                     ->icon('heroicon-o-calendar')
                     ->label('Datum poslední objednávky')
-                    ->dateTime('d.m.Y H:i:s')
+                    ->dateTime(AppHelper::DATE_TIME_FULL_FORMAT)
                     ->sortable(),
                 TextColumn::make('unit_price')
                     ->label('Cena za jednotku')

--- a/app/Filament/Resources/SportEvents/RelationManagers/UserCreditRelationManager.php
+++ b/app/Filament/Resources/SportEvents/RelationManagers/UserCreditRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SportEvents\RelationManagers;
 
+use App\Shared\Helpers\AppHelper;
 use App\Models\UserCredit;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\Summarizers\Sum;
@@ -30,7 +31,7 @@ class UserCreditRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('created_at')
                     ->label('Vytvořeno')
-                    ->dateTime('d.m.Y'),
+                    ->dateTime(AppHelper::DATE_FORMAT),
                 TextColumn::make('userRaceProfile.UserRaceFullName')
                     ->label('Závodní profil')
                     ->searchable(),

--- a/app/Filament/Resources/SportEvents/SportEventResource.php
+++ b/app/Filament/Resources/SportEvents/SportEventResource.php
@@ -96,7 +96,7 @@ class SportEventResource extends Resource implements HasShieldPermissions
                         fn (
                             SportEvent $record
                         ): string => $record->last_update ? 'Poslední hromadná aktualizace: '.$record->last_update->format(
-                            'd.m.Y - H:i'
+                            AppHelper::DATE_TIME_FORMAT
                         ) : ''
                     )
                     ->label('Název')
@@ -111,7 +111,7 @@ class SportEventResource extends Resource implements HasShieldPermissions
                     ->description(function (SportEvent $record) {
                         $dateEnd = $record->date_end;
                         if ($dateEnd !== null) {
-                            return $record->date->format('d').' - '.$record->date_end->format('d.m.Y');
+                            return $record->date->format('d').' - '.$record->date_end->format(AppHelper::DATE_FORMAT);
                         }
 
                         return '';
@@ -194,7 +194,7 @@ class SportEventResource extends Resource implements HasShieldPermissions
                             return null;
                         }
 
-                        return 'Závody novější: '.Carbon::parse($data['date'])->format('d.m.Y');
+                        return 'Závody novější: '.Carbon::parse($data['date'])->format(AppHelper::DATE_FORMAT);
                     })->default(now()->subDays(7)),
                 SelectFilter::make('discipline_id')
                     ->label('Disciplína')
@@ -350,11 +350,11 @@ class SportEventResource extends Resource implements HasShieldPermissions
                                 Grid::make()->schema([
                                     DatePicker::make('date')
                                         ->label('Datum od')
-                                        ->displayFormat('d.m.Y')
+                                        ->displayFormat(AppHelper::DATE_FORMAT)
                                         ->required(),
                                     DatePicker::make('date_end')
                                         ->label('Datum do')
-                                        ->displayFormat('d.m.Y')
+                                        ->displayFormat(AppHelper::DATE_FORMAT)
                                         ->hint('Použij u vícedenních závodů'),
                                     TextInput::make('stages')
                                         ->label('Etap')

--- a/app/Filament/Resources/UserEntries/InfoList/UserEntryOverview.php
+++ b/app/Filament/Resources/UserEntries/InfoList/UserEntryOverview.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\UserEntries\InfoList;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Enums\TextSize;
 use Filament\Infolists\Components\IconEntry;
@@ -24,7 +25,7 @@ class UserEntryOverview
                     TextEntry::make('sportEvent.date')
                         ->label('Datum konání akce:')
                         ->icon('heroicon-m-calendar-days')
-                        ->dateTime('d.m.Y')
+                        ->dateTime(AppHelper::DATE_FORMAT)
                         ->size(TextSize::Large),
                     TextEntry::make('sportEvent.place')
                         ->label('Místo:')

--- a/app/Filament/Resources/UserEntries/UserEntryResource.php
+++ b/app/Filament/Resources/UserEntries/UserEntryResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\UserEntries;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
@@ -72,7 +73,7 @@ class UserEntryResource extends Resource implements HasShieldPermissions
                     ->label('Registrace'),
                 TextColumn::make('sportEvent.date')
                     ->label('Datum')
-                    ->dateTime('d. m. Y')
+                    ->dateTime(AppHelper::DATE_FORMAT)
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('requested_start')

--- a/app/Filament/Resources/UserRaceProfiles/UserRaceProfileResource.php
+++ b/app/Filament/Resources/UserRaceProfiles/UserRaceProfileResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\UserRaceProfiles;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
@@ -255,7 +256,7 @@ class UserRaceProfileResource extends Resource implements HasShieldPermissions
                     ->description(function (UserRaceProfile $model): ?string {
                         if (! $model->active) {
                             return __('user-race-profile.table.active_until').': '.$model->active_until?->format(
-                                'd.m.Y'
+                                AppHelper::DATE_FORMAT
                             );
                         }
 

--- a/app/Filament/Resources/Users/RelationManagers/UserCreditRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/UserCreditRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Users\RelationManagers;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Schemas\Schema;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\DatePicker;
@@ -59,7 +60,7 @@ class UserCreditRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('created_at')
                     ->label(__('user-credit.table.created_at_title'))
-                    ->dateTime('d.m.Y')
+                    ->dateTime(AppHelper::DATE_FORMAT)
                     ->description(function (UserCredit $record): string {
                         return 'id: '. $record->id;
                     })
@@ -140,7 +141,7 @@ class UserCreditRelationManager extends RelationManager
                             ->withColumns([
                                 Column::make('created_at')
                                     ->heading('Vytvořeno dne')
-                                    ->formatStateUsing(fn ($state) => Carbon::parse($state)->format('d.m.Y')),
+                                    ->formatStateUsing(fn ($state) => Carbon::parse($state)->format(AppHelper::DATE_FORMAT)),
                                 Column::make('sportEvent.name')->heading('Název události'),
                                 Column::make('sportEvent.alt_name')->heading('Alternativní název'),
                                 Column::make('userRaceProfile.reg_number')->heading('Registrace'),

--- a/app/Http/Controllers/Discord/RaceEventAddedNotification.php
+++ b/app/Http/Controllers/Discord/RaceEventAddedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Discord;
 
+use App\Shared\Helpers\AppHelper;
 use App\Http\Controllers\Controller;
 use App\Models\SportEvent;
 use App\Services\OrisApiService;
@@ -31,7 +32,7 @@ final class RaceEventAddedNotification extends Controller
 
         $embeds[] = [
             'title' => $this->sportEvent->name,
-            'description' => sprintf('Přihláška do: %s | ORIS: %s', Carbon::parse($this->sportEvent->entry_date_1)->format('m.d.Y H:i'), $raceEventOrisLink),
+            'description' => sprintf('Přihláška do: %s | ORIS: %s', Carbon::parse($this->sportEvent->entry_date_1)->format(AppHelper::DATE_TIME_FORMAT), $raceEventOrisLink),
             'color' => '5763719',
         ];
 

--- a/app/Http/Controllers/Discord/RaceEventCronNotification.php
+++ b/app/Http/Controllers/Discord/RaceEventCronNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Discord;
 
+use App\Shared\Helpers\AppHelper;
 use App\Http\Controllers\Controller;
 use App\Models\SportEvent;
 use App\Services\OrisApiService;
@@ -35,7 +36,7 @@ final class RaceEventCronNotification extends Controller
 
                 $embeds[] = [
                     'title' => $raceEvent->name,
-                    'description' => sprintf('Přihláška do: %s | ORIS: %s', Carbon::parse($raceEvent->entry_date_1)->format('m.d.Y H:i'), $raceEventOrisLink),
+                    'description' => sprintf('Přihláška do: %s | ORIS: %s', Carbon::parse($raceEvent->entry_date_1)->format(AppHelper::DATE_TIME_FORMAT), $raceEventOrisLink),
                     'color' => '7506394',
                 ];
             }

--- a/app/Livewire/Backend/UserRaceProfileTable.php
+++ b/app/Livewire/Backend/UserRaceProfileTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Backend;
 
+use App\Shared\Helpers\AppHelper;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Support\Enums\TextSize;
@@ -49,7 +50,7 @@ class UserRaceProfileTable extends Component implements HasForms, HasTable, HasA
                     })
                     ->description(function (UserRaceProfile $model): ?string {
                         if (!$model->active) {
-                            return __('user-race-profile.table.active_until') . ': ' . $model->active_until?->format('d.m.Y');
+                            return __('user-race-profile.table.active_until') . ': ' . $model->active_until?->format(AppHelper::DATE_FORMAT);
                         }
                         return null;
                     }),
@@ -90,12 +91,12 @@ class UserRaceProfileTable extends Component implements HasForms, HasTable, HasA
                     ->hidden(!$this->isSuperAdmin()),
                 TextColumn::make('created_at')
                     ->label(__('user-race-profile.table.created_at'))
-                    ->dateTime('d.m.Y')
+                    ->dateTime(AppHelper::DATE_FORMAT)
                     ->sortable()
                     ->searchable(),
                 TextColumn::make('active_until')
                     ->label(__('user-race-profile.table.active_until'))
-                    ->dateTime('d.m.Y')
+                    ->dateTime(AppHelper::DATE_FORMAT)
                     ->sortable()
                     ->searchable(),
                 TextColumn::make('user.name')

--- a/app/Livewire/UserCredit/UserCreditList.php
+++ b/app/Livewire/UserCredit/UserCreditList.php
@@ -39,7 +39,7 @@ class UserCreditList extends Component implements HasForms, HasTable, HasActions
             ->columns([
                 TextColumn::make('created_at')
                     ->label(__('user-credit.table.created_at_title'))
-                    ->dateTime('d.m.Y')
+                    ->dateTime(AppHelper::DATE_FORMAT)
                     ->description(function (UserCredit $record): string {
                         return 'ID:'.$record->id;
                     })

--- a/app/Models/SportEvent.php
+++ b/app/Models/SportEvent.php
@@ -227,7 +227,7 @@ class SportEvent extends Model
             $this->name.' | '.
             ($this->oris_id !== null ? '(ORIS ID: '.$this->oris_id.')' : '').
             ($this->last_calculate_cost !== null ? ' | (Náklady naposled : '.$this->last_calculate_cost->format(
-                'd.m.Y - H:i'
+                AppHelper::DATE_TIME_FORMAT
             ).')' : '');
     }
 }

--- a/resources/views/emails/event/addUpdateSportEvent.blade.php
+++ b/resources/views/emails/event/addUpdateSportEvent.blade.php
@@ -15,7 +15,7 @@ Do systemu byly přidány závody:
     | Závod              | Přihláska do         |
     | :----------------- |:------------- |
     @foreach ($sportEvents as $sportEvent)
-        | {{$sportEvent->name }}<br>@if(EmptyType::stringNotEmpty($sportEvent->alt_name)) {{Str::limit($sportEvent->alt_name, 35)}}@endif  | {{\Carbon\Carbon::parse($sportEvent->date)->format('Y.m.d H:i')}}  |
+        | {{$sportEvent->name }}<br>@if(EmptyType::stringNotEmpty($sportEvent->alt_name)) {{Str::limit($sportEvent->alt_name, 35)}}@endif  | {{\Carbon\Carbon::parse($sportEvent->date)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}}  |
     @endforeach
 @endcomponent
 

--- a/resources/views/emails/event/entryEndsToPay.blade.php
+++ b/resources/views/emails/event/entryEndsToPay.blade.php
@@ -26,11 +26,11 @@ Závody u kterých právě končí **{{$deadline}} termín** přihlášek.
     | :----------------- |:------------- |:------------- |
     @foreach ($sportEvents as $event)
         @if ($deadline === 1)
-        | {{ Carbon::parse($event->entry_date_1)->format('d.m.Y - H:i') }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
+        | {{ Carbon::parse($event->entry_date_1)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
         @elseif($deadline === 2)
-        | {{ Carbon::parse($event->entry_date_2)->format('d.m.Y - H:i') }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
+        | {{ Carbon::parse($event->entry_date_2)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
         @elseif($deadline === 3)
-        | {{ Carbon::parse($event->entry_date_3)->format('d.m.Y - H:i') }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
+        | {{ Carbon::parse($event->entry_date_3)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}  | {{$event->name }} | @if($event->oris_id !== null)[{{$event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$event->oris_id}})@endif  |
         @endif
     @endforeach
 @endcomponent

--- a/resources/views/emails/event/eventNotification.blade.php
+++ b/resources/views/emails/event/eventNotification.blade.php
@@ -5,7 +5,7 @@
 @component('mail::divider')
 Zpráva k závodu **{{ $sportEvent->name }}** @if(!is_null($sportEvent->alt_name)) | {{ $sportEvent->alt_name }} @endif odeslána na všechny aktuálně přihlášené závodníky.
 
-- Datum: **{{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $sportEvent->date)->format('d.h.Y') ?? ''}}**
+- Datum: **{{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $sportEvent->date)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) ?? ''}}**
 - Místo: **{{ $sportEvent->place ?? ''}}**
 @endcomponent
 

--- a/resources/views/emails/event/eventWeeklyEndsBySport.blade.php
+++ b/resources/views/emails/event/eventWeeklyEndsBySport.blade.php
@@ -17,7 +17,7 @@ use App\Services\OrisApiService;
 ## Konec přihlášek
 
 Týdenní souhrn přihlášek závodů vypsaných níže. Závody jsou rozděleny podle termínu přihlášek v týdnu
- **{{ Carbon::now()->addDay()->format('d.m.Y') }}** - **{{ Carbon::now()->addDays(8)->format('d.m.Y') }}**.
+ **{{ Carbon::now()->addDay()->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}** - **{{ Carbon::now()->addDays(8)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}**.
 
 @if(!is_null($eventFirstDateEnd))
 @component('mail::divider')
@@ -30,7 +30,7 @@ Závody u kterých končí **první termín** přihlášek.
 | Přihláška do       | Datum akce         | Název akce/závodu   |
 | :----------------- |:------------------ |:------------------ |
 @foreach ($eventFirstDateEnd as $firstDate)
-| {{ Carbon::parse($firstDate->entry_date_1)->format('d.m.Y - H:i') }} | @if(EmptyType::stringNotEmpty($firstDate->alt_name)){{ Carbon::parse($firstDate->date)->format('d.m.Y') }}@endif | @if($firstDate->oris_id !== null)[{{$firstDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$firstDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($firstDate->alt_name)){{Str::limit($firstDate->alt_name, 35)}}@endif | @if($firstDate->oris_id !== null)[{{$firstDate->oris_id }}](https://oris.orientacnisporty.cz/Zavod?id={{$firstDate->oris_id}})@endif  |
+| {{ Carbon::parse($firstDate->entry_date_1)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }} | @if(EmptyType::stringNotEmpty($firstDate->alt_name)){{ Carbon::parse($firstDate->date)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}@endif | @if($firstDate->oris_id !== null)[{{$firstDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$firstDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($firstDate->alt_name)){{Str::limit($firstDate->alt_name, 35)}}@endif | @if($firstDate->oris_id !== null)[{{$firstDate->oris_id }}](https://oris.orientacnisporty.cz/Zavod?id={{$firstDate->oris_id}})@endif  |
 @endforeach
 @endcomponent
 @endif
@@ -47,7 +47,7 @@ Závody u kterých končí **druhý termín** přihlášek.
 | Přihláška do       | Datum akce         | Název akce/závodu   |
 | :----------------- |:------------------ |:------------------ |
 @foreach ($eventSecondDateEnd as $secondDate)
-| {{ Carbon::parse($secondDate->entry_date_2)->format('d.m.Y - H:i') }} | @if(EmptyType::stringNotEmpty($secondDate->alt_name)){{ Carbon::parse($secondDate->date)->format('d.m.Y') }}@endif | @if($secondDate->oris_id !== null) [{{$secondDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$secondDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($secondDate->alt_name)){{Str::limit($secondDate->alt_name, 35)}}@endif | @if($secondDate->oris_id !== null)[{{$secondDate->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$secondDate->oris_id}})@endif  |
+| {{ Carbon::parse($secondDate->entry_date_2)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }} | @if(EmptyType::stringNotEmpty($secondDate->alt_name)){{ Carbon::parse($secondDate->date)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}@endif | @if($secondDate->oris_id !== null) [{{$secondDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$secondDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($secondDate->alt_name)){{Str::limit($secondDate->alt_name, 35)}}@endif | @if($secondDate->oris_id !== null)[{{$secondDate->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$secondDate->oris_id}})@endif  |
 @endforeach
 
 @endcomponent
@@ -65,7 +65,7 @@ Závody u kterých končí **třetí termín** přihlášek.
 | Přihláška do       | Datum akce         | Název akce/závodu   |
 | :----------------- |:------------------ |:------------------ |
 @foreach ($eventThirdDateEnd as $thirdDate)
-| {{ Carbon::parse($thirdDate->entry_date_3)->format('d.m.Y - H:i') }} | @if(EmptyType::stringNotEmpty($thirdDate->alt_name)) {{ Carbon::parse($thirdDate->date)->format('d.m.Y') }}@endif | @if($thirdDate->oris_id !== null) [{{$thirdDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$thirdDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($thirdDate->alt_name)){{Str::limit($thirdDate->alt_name, 35)}}@endif | @if($thirdDate->oris_id !== null)[{{$thirdDate->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$thirdDate->oris_id}})@endif  |
+| {{ Carbon::parse($thirdDate->entry_date_3)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }} | @if(EmptyType::stringNotEmpty($thirdDate->alt_name)) {{ Carbon::parse($thirdDate->date)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}@endif | @if($thirdDate->oris_id !== null) [{{$thirdDate->name}}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$thirdDate->oris_id}})@endif<br>@if(EmptyType::stringNotEmpty($thirdDate->alt_name)){{Str::limit($thirdDate->alt_name, 35)}}@endif | @if($thirdDate->oris_id !== null)[{{$thirdDate->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$thirdDate->oris_id}})@endif  |
 @endforeach
 @endcomponent
 @endif

--- a/resources/views/emails/event/nearest.blade.php
+++ b/resources/views/emails/event/nearest.blade.php
@@ -9,7 +9,7 @@ Příhlášení proveď podle pokynů v administraci.
     | Přihláska do       | Název akce/závodu        |
     | :----------------- |:------------- |
     @foreach ($sportEvents as $sportEvent)
-        | {{  \Carbon\Carbon::parse($sportEvent->date)->format('Y.m.d H:i') }}  | {{$sportEvent->name }}  |
+        | {{  \Carbon\Carbon::parse($sportEvent->date)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}  | {{$sportEvent->name }}  |
     @endforeach
 @endcomponent
 

--- a/resources/views/emails/event/sportEntryEnds.blade.php
+++ b/resources/views/emails/event/sportEntryEnds.blade.php
@@ -15,7 +15,7 @@ Příhlášení proveď podle pokynů v administraci.
     | Přihláška do       | Název akce/závodu        | ORIS ID
     | :----------------- |:------------- |:------------- |
     @foreach ($sportEventContent as $sportEvent)
-        | {{\Carbon\Carbon::parse($sportEvent->entry_date_1)->format('d.m.Y - H:i')}}  | {{$sportEvent->name }}<br>@if(EmptyType::stringNotEmpty($sportEvent->alt_name)) {{Str::limit($sportEvent->alt_name, 35)}}@endif   | @if($sportEvent->oris_id !== null)[{{$sportEvent->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$sportEvent->oris_id}})@endif  |
+        | {{\Carbon\Carbon::parse($sportEvent->entry_date_1)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}}  | {{$sportEvent->name }}<br>@if(EmptyType::stringNotEmpty($sportEvent->alt_name)) {{Str::limit($sportEvent->alt_name, 35)}}@endif   | @if($sportEvent->oris_id !== null)[{{$sportEvent->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{$sportEvent->oris_id}})@endif  |
     @endforeach
 @endcomponent
 

--- a/resources/views/emails/event/userAppNotification.blade.php
+++ b/resources/views/emails/event/userAppNotification.blade.php
@@ -7,7 +7,7 @@ Upozornění z interního systemu {{ Config::get('site-config.club.abbr') }} na 
 @component('mail::divider')
 Zpráva od uživatele **{{ $user->name }}**.
 
-- Zpráva zaslána dne: **{{ \Carbon\Carbon::now()->format('d.h.Y H:i') ?? ''}}**
+- Zpráva zaslána dne: **{{ \Carbon\Carbon::now()->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) ?? ''}}**
 @endcomponent
 
 {{ $content }}

--- a/resources/views/emails/event/userCreditChange.blade.php
+++ b/resources/views/emails/event/userCreditChange.blade.php
@@ -14,13 +14,13 @@ use App\Enums\UserParamType;
 
 Na účtu uživatele **{{ $user->name }}** došlo k pohybu.
 
-Aktuální výše uživatelského konta: **{{ $user->getParam(UserParamType::UserActualBalance) }}** Kč k datu **{{ Carbon::now()->format('d.m.Y H:i') }}**.
+Aktuální výše uživatelského konta: **{{ $user->getParam(UserParamType::UserActualBalance) }}** Kč k datu **{{ Carbon::now()->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}**.
 
 @component('mail::divider')
 ## Pohyb z poslední transakce
 
 - částka: **{{ $userCredit->amount }} Kč**
-- datum transakce: {{ Carbon::parse($userCredit->created_at)->format('d.m.Y H:i') }}
+- datum transakce: {{ Carbon::parse($userCredit->created_at)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
 - ID transakce: {{ $userCredit->id }}
 - vazba na ID bankovní transakce: {{ $userCredit->bank_transaction_id }}
 

--- a/resources/views/emails/user/userInDebit.blade.php
+++ b/resources/views/emails/user/userInDebit.blade.php
@@ -8,7 +8,7 @@
 ## Uživatelé s nízkým kreditem
 
 Měsíční výpis uživatelů {{ Config::get('site-config.club.abbr') }} klubu k dnešnímu dni
-{{ Carbon::now()->format('d.m.Y H:i') }}, kteří k prvnímu mají nízký kredit na kontě.
+{{ Carbon::now()->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}, kteří k prvnímu mají nízký kredit na kontě.
 
 Prosím o kontrolu s následou informací k uživatelům:
 

--- a/resources/views/filament/modals/user-add-credit-admin.blade.php
+++ b/resources/views/filament/modals/user-add-credit-admin.blade.php
@@ -15,7 +15,7 @@
                         <div
                             class="absolute w-3 h-3 bg-yellow-400 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-yellow-400"></div>
                         <time class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                            {{ $userCreditNote->created_at->format('d.m.Y H:i') }}
+                            {{ $userCreditNote->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                         </time>
                         <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                         <div class="app-front-content">
@@ -31,7 +31,7 @@
                         <div
                             class="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-gray-700"></div>
                         <time class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                            {{ $userCreditNote->created_at->format('d.m.Y H:i') }}
+                            {{ $userCreditNote->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                         </time>
                         <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                         <p class="app-front-content">

--- a/resources/views/filament/pages/user-settings.blade.php
+++ b/resources/views/filament/pages/user-settings.blade.php
@@ -1,7 +1,7 @@
 @php
     use App\Enums\AppRoles;
     use App\Models\SportEvent;
-    use App\Shared\Helpers\AppHelper;
+
 
     $record = SportEvent::query()->where('id', '=', 150)->first();
 @endphp
@@ -26,7 +26,7 @@
                     <div>
                         <h3 class="block font-bold text-gray-800 dark:text-white">{{ auth()->user()?->name }}</h3>
                         <p class="text-gray-600 dark:text-gray-400">Registrace
-                            od {{ \Carbon\Carbon::createFromFormat(AppHelper::MYSQL_DATE_TIME, auth()->user()?->created_at)->format('d.m.Y')}}
+                            od {{ \Carbon\Carbon::createFromFormat(\App\Shared\Helpers\AppHelper::MYSQL_DATE_TIME, auth()->user()?->created_at)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT)}}
                             na e-mail: {{ auth()->user()?->email }}</p>
                         <p class="mt-4">Aktuální role:</p>
 

--- a/resources/views/filament/resources/sport-event-resource/pages/event-entry.blade.php
+++ b/resources/views/filament/resources/sport-event-resource/pages/event-entry.blade.php
@@ -5,7 +5,7 @@
     use App\Models\SportService;
     use App\Enums\AppRoles;
     use App\Services\OrisApiService;
-    use App\Shared\Helpers\AppHelper;use Carbon\Carbon;
+    use Carbon\Carbon;
 
     /** @var SportEvent $record */
     /** @var SportClass[] $classes **/
@@ -178,7 +178,7 @@
                                             <path d="M4 11l16 0"></path>
                                             <path d="M8 15h2v2h-2z"></path>
                                         </svg>
-                                        <span>{{ $record->date->format('d. m. Y') }}</span>
+                                        <span>{{ $record->date->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}</span>
                                     </li>
                                 @endif
                                 @if ($record->entry_date_1 !== null)
@@ -192,7 +192,7 @@
                                             <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path>
                                             <path d="M10 10l2 -2v8"></path>
                                         </svg>
-                                        <span>{{ $record->entry_date_1->format('d. m. Y H:i') }}</span>
+                                        <span>{{ $record->entry_date_1->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</span>
                                     </li>
                                 @endif
                                 @if ($record->entry_date_2 !== null)
@@ -207,7 +207,7 @@
                                             <path
                                                 d="M10 8h3a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2a1 1 0 0 0 -1 1v2a1 1 0 0 0 1 1h3"></path>
                                         </svg>
-                                        <span>{{ $record->entry_date_2->format('d. m. Y H:i') }}</span>
+                                        <span>{{ $record->entry_date_2->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</span>
                                     </li>
                                 @endif
                                 @if ($record->entry_date_3 !== null)
@@ -222,7 +222,7 @@
                                             <path
                                                 d="M10 9a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2h2a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1"></path>
                                         </svg>
-                                        <span>{{ $record->entry_date_3->format('d. m. Y H:i') }}</span>
+                                        <span>{{ $record->entry_date_3->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</span>
                                     </li>
                                 @endif
                             </ul>
@@ -297,7 +297,7 @@
                                 <dl class="text-gray-900 divide-y divide-gray-200 dark:text-white dark:divide-gray-700">
                                     @foreach($record->sportEventNews()->get() as $quickNews)
                                         <div class="flex flex-col pb-2">
-                                            <dt class="mb-1 text-gray-500 dark:text-gray-400">{{ Carbon::parse($quickNews->date)->format('d.m.Y - H:i') }}</dt>
+                                            <dt class="mb-1 text-gray-500 dark:text-gray-400">{{ Carbon::parse($quickNews->date)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</dt>
                                             <dd class="font-semibold">{{$quickNews->text}}</dd>
                                         </div>
                                     @endforeach

--- a/resources/views/filament/resources/user-credit-resource/widgets/user-credit-chat.blade.php
+++ b/resources/views/filament/resources/user-credit-resource/widgets/user-credit-chat.blade.php
@@ -27,7 +27,7 @@
                 @endif
                         <div class="absolute w-3 h-3 bg-yellow-400 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-yellow-400"></div>
                         <time class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                            {{ $note->created_at->format('d.m.Y H:i') }}
+                            {{ $note->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                         </time>
                         <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                         <div class="app-front-content">
@@ -42,7 +42,7 @@
                         @endif
                         <div class="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-gray-700"></div>
                         <time class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                            {{ $note->created_at->format('d.m.Y H:i') }}
+                            {{ $note->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                         </time>
                         <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                         <p class="app-front-content">

--- a/resources/views/filament/resources/user-credit-resource/widgets/user-credit-overview.blade.php
+++ b/resources/views/filament/resources/user-credit-resource/widgets/user-credit-overview.blade.php
@@ -58,7 +58,7 @@
                 </li>
                 <li>
                     Přihlášeno: <span class="font-semibold text-gray-900 dark:text-white">
-                    {{ Carbon::createFromFormat('Y-m-d H:i:s', $orisApiResponse->params['CreatedDateTime'])->format('d. m. Y H:i') }}
+                    {{ Carbon::createFromFormat('Y-m-d H:i:s', $orisApiResponse->params['CreatedDateTime'])->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                 </span>
                 </li>
                 @if(EmptyType::stringNotEmpty($orisApiResponse->params['UpdatedByUserID']))

--- a/resources/views/filament/shared/leaflet-map-widget.blade.php
+++ b/resources/views/filament/shared/leaflet-map-widget.blade.php
@@ -53,7 +53,7 @@
 
             if (!$mapData['eventMap']) {
                 if ($marker->date !== null) {
-                $popupContent .= '<br /><span class="text-sm text-black">Datum konání: ' . $marker->date->format('d.m.Y') .'</span>';
+                $popupContent .= '<br /><span class="text-sm text-black">Datum konání: ' . $marker->date->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) .'</span>';
                 }
 
                 if ($marker->date !== null && is_array($marker->region)) {

--- a/resources/views/filament/tables/columns/entry-name.blade.php
+++ b/resources/views/filament/tables/columns/entry-name.blade.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Models\SportEvent;
-use App\Shared\Helpers\AppHelper;
+
 use Illuminate\Support\Carbon;
 
 /**

--- a/resources/views/filament/tables/columns/entry-name.blade.php
+++ b/resources/views/filament/tables/columns/entry-name.blade.php
@@ -2,8 +2,6 @@
 
 use App\Models\SportEvent;
 
-use Illuminate\Support\Carbon;
-
 /**
  * @var SportEvent $sportEvent
  */

--- a/resources/views/filament/tables/columns/entryDates.blade.php
+++ b/resources/views/filament/tables/columns/entryDates.blade.php
@@ -1,5 +1,5 @@
 <?php
-use App\Shared\Helpers\AppHelper;
+
 use Illuminate\Support\Carbon;
 use App\Models\SportEvent;
 
@@ -16,7 +16,7 @@ $sportEvent = $getRecord();
             @elseif(Carbon::now() > $sportEvent->entry_date_1)
                 text-danger-600
             @endif
-        ">{{ $sportEvent->entry_date_1?->format(AppHelper::DATE_TIME_FORMAT ?? '') }}</p>
+        ">{{ $sportEvent->entry_date_1?->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</p>
     @endif
 
     @if ($getRecord()->entry_date_2 !== null)
@@ -28,7 +28,7 @@ $sportEvent = $getRecord();
             @endif
         ">
             <div class="flex justify-start">
-                <div>{{ $sportEvent->entry_date_2?->format(AppHelper::DATE_TIME_FORMAT ?? '') }}</div>
+                <div>{{ $sportEvent->entry_date_2?->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</div>
                 @if ($sportEvent->increase_entry_fee_2 !== null)
                 <div class="ml-1 bg-yellow-100 text-yellow-800 text-xs font-medium me-2 px-1 py-0.5 rounded dark:bg-gray-700 dark:text-yellow-300 border border-yellow-300">+{{$sportEvent->increase_entry_fee_2}}%</div>
                 @endif
@@ -44,7 +44,7 @@ $sportEvent = $getRecord();
                 text-danger-600
             @endif
         "><div class="flex justify-start">
-                <div>{{ $sportEvent->entry_date_3?->format(AppHelper::DATE_TIME_FORMAT ?? '') }}</div>
+                <div>{{ $sportEvent->entry_date_3?->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</div>
                 @if ($sportEvent->increase_entry_fee_3 !== null)
                     <div class="ml-1 bg-yellow-100 text-yellow-800 text-xs font-medium me-2 px-1 py-0.5 rounded dark:bg-gray-700 dark:text-yellow-300 border border-yellow-300">+{{$sportEvent->increase_entry_fee_3}}%</div>
                 @endif

--- a/resources/views/livewire/frontend/result-list.blade.php
+++ b/resources/views/livewire/frontend/result-list.blade.php
@@ -20,7 +20,7 @@
         </div>
         <div>
             <div class="mt-0 pt-0 ml-3">
-                <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format('d.m.Y - H:i')}} | </span>
+                <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}} | </span>
                 <span class="text-gray-400 text-md font-normal">{{$eventAttributes[0]->getCreator()}} </span>
             </div>
         </div>

--- a/resources/views/livewire/frontend/startlist.blade.php
+++ b/resources/views/livewire/frontend/startlist.blade.php
@@ -20,7 +20,7 @@
                 </div>
                 <div>
                     <div class="mt-0 pt-0 ml-3">
-                        <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format('d.m.Y - H:i')}} | </span>
+                        <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}} | </span>
                         <span class="text-gray-400 text-md font-normal">{{$eventAttributes[0]->getCreator()}} </span>
                     </div>
                 </div>

--- a/resources/views/pages/frontend/single-event.blade.php
+++ b/resources/views/pages/frontend/single-event.blade.php
@@ -41,9 +41,9 @@
                         <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
                         </svg>
-                        {{ $event->date->format('d.m.Y') }}
+                        {{ $event->date->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}
                         @if($event->date_end && $event->date_end->gt($event->date))
-                            — {{ $event->date_end->format('d.m.Y') }}
+                            — {{ $event->date_end->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}
                         @endif
                     </div>
 
@@ -189,15 +189,15 @@
                             <tbody>
                                 @if($event->entry_date_1)
                                     <tr class="border-b dark:border-gray-600 {{ Carbon::parse($event->entry_date_1)->isPast() ? 'opacity-50' : '' }}">
-                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">1. termin</td>
-                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_1)->format('d.m.Y H:i') }}</td>
+                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">1. termín</td>
+                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_1)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</td>
                                         <td class="px-4 py-2 text-gray-900 dark:text-white">—</td>
                                     </tr>
                                 @endif
                                 @if($event->entry_date_2)
                                     <tr class="border-b dark:border-gray-600 {{ Carbon::parse($event->entry_date_2)->isPast() ? 'opacity-50' : '' }}">
-                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">2. termin</td>
-                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_2)->format('d.m.Y H:i') }}</td>
+                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">2. termín</td>
+                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_2)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</td>
                                         <td class="px-4 py-2 text-gray-900 dark:text-white">
                                             @if($event->increase_entry_fee_2)
                                                 +{{ $event->increase_entry_fee_2 }} Kc
@@ -209,8 +209,8 @@
                                 @endif
                                 @if($event->entry_date_3)
                                     <tr class="border-b dark:border-gray-600 {{ Carbon::parse($event->entry_date_3)->isPast() ? 'opacity-50' : '' }}">
-                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">3. termin</td>
-                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_3)->format('d.m.Y H:i') }}</td>
+                                        <td class="px-4 py-2 font-medium text-gray-900 dark:text-white">3. termín</td>
+                                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ Carbon::parse($event->entry_date_3)->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}</td>
                                         <td class="px-4 py-2 text-gray-900 dark:text-white">
                                             @if($event->increase_entry_fee_3)
                                                 +{{ $event->increase_entry_fee_3 }} Kc
@@ -349,7 +349,7 @@
                         @foreach($event->sportEventNews->sortByDesc('date') as $news)
                             <div class="p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
                                 <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">
-                                    {{ Carbon::parse($news->date)->format('d.m.Y') }}
+                                    {{ Carbon::parse($news->date)->format(\App\Shared\Helpers\AppHelper::DATE_FORMAT) }}
                                 </div>
                                 <div class="text-gray-800 dark:text-gray-200">
                                     {!! $news->text !!}

--- a/resources/views/pages/frontend/single-result-list.blade.php
+++ b/resources/views/pages/frontend/single-result-list.blade.php
@@ -24,7 +24,7 @@
             </div>
             <div>
                 <div class="mt-0 pt-0 ml-3">
-                    <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format('d.m.Y - H:i')}} | </span>
+                    <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}} | </span>
                     <span class="text-gray-400 text-md font-normal">{{$eventAttributes[0]->getCreator()}} </span>
                 </div>
             </div>

--- a/resources/views/pages/frontend/single-start-list.blade.php
+++ b/resources/views/pages/frontend/single-start-list.blade.php
@@ -23,7 +23,7 @@
                 </div>
                 <div>
                     <div class="mt-0 pt-0 ml-3">
-                        <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format('d.m.Y - H:i')}} | </span>
+                        <span class="text-gray-400 text-md font-normal"> {{\Carbon\Carbon::parse($eventAttributes[0]->getCreateTime(), 'Europe/Prague')->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT)}} | </span>
                         <span class="text-gray-400 text-md font-normal">{{$eventAttributes[0]->getCreator()}} </span>
                     </div>
                 </div>

--- a/resources/views/partials/backend/user-credit-notes.blade.php
+++ b/resources/views/partials/backend/user-credit-notes.blade.php
@@ -27,7 +27,7 @@
                             <div
                                 class="absolute w-3 h-3 bg-yellow-400 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-yellow-400"></div>
                             <time class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                                {{ $note->created_at->format('d.m.Y H:i') }}
+                                {{ $note->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                             </time>
                             <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                             <div class="app-front-content">
@@ -44,7 +44,7 @@
                                         class="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -left-1.5 border border-white dark:border-gray-900 dark:bg-gray-700"></div>
                                     <time
                                         class="mb-1 text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
-                                        {{ $note->created_at->format('d.m.Y H:i') }}
+                                        {{ $note->created_at->format(\App\Shared\Helpers\AppHelper::DATE_TIME_FORMAT) }}
                                     </time>
                                     <h4 class="text-lg font-semibold text-gray-900 dark:text-white">{{$userName}}</h4>
                                     <p class="app-front-content">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced numerous hard-coded date/time formats with centralized configurable format constants across tables, lists, emails, frontend pages, admin views and widgets — unifying displayed dates while preserving behavior and providing safe fallbacks when formats are unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->