### PR TITLE
Select category in race missing

### DIFF
--- a/app/Filament/Resources/SportEvents/Pages/CreateSportEvent.php
+++ b/app/Filament/Resources/SportEvents/Pages/CreateSportEvent.php
@@ -34,7 +34,9 @@ class CreateSportEvent extends CreateRecord
         /** @var SportEvent $sportEvent */
         $sportEvent = $this->record;
 
-        $recipients = User::whereHas("roles", function ($q) { $q->whereIn('name', ['super_admin', 'event_master']); })->get();
+        $recipients = User::whereHas("roles", function ($q) {
+            $q->whereIn('name', ['super_admin', 'event_master']);
+        })->get();
 
         foreach ($recipients as $recipient) {
             Notification::make()

--- a/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
+++ b/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
@@ -488,19 +488,24 @@ class EntrySportEvent extends Page implements HasForms, HasTable
                         if ($this->record->oris_id !== null && $this->record->use_oris_for_entries) {
                             return $get('specific_response_class_id');
                         } else {
+                            /** @var SportClass[] $eventClasses */
                             $eventClasses = SportClass::where('sport_event_id', '=', $this->record->id)
                                 ->get();
 
                             $classes = [];
                             foreach ($eventClasses as $eventClass) {
                                 $classDefinitionName = SportClassDefinition::where('id', '=', $eventClass->class_definition_id)->first();
-                                $classes[$eventClass->id] = $classDefinitionName->classDefinitionFullLabel;
+                                $classes[$eventClass->id] = '<span class="font-medium">' . e($eventClass->name)
+                                    . '</span> <span class="text-gray-400"> | '
+                                    . e($classDefinitionName->classDefinitionFullLabel)
+                                    . '</span>';
                             }
 
                             return $classes;
                         }
                     })
                     ->searchable()
+                    ->allowHtml()
                     ->required()
                     ->loadingMessage('Nahrávám kategorie...'),
 


### PR DESCRIPTION
Show eventClass->name in category list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced event class selection display in the sport event entry form with improved formatting—event class names now appear in bold alongside their full definitions for better readability and information clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->