### PR TITLE
[SECURITY] Replace sha1(time()) password generation with Str::random(12)

### DIFF
--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -231,7 +231,7 @@ class UserResource extends Resource implements HasShieldPermissions
                     ->label('Nové heslo')
                     ->required()
                     ->readOnly()
-                    ->default(Str::random(10)),
+                    ->default(Str::random(12)),
 
             ])
             ->action(function (User $user, array $data): void {

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -79,7 +79,7 @@ class UserResource extends Resource implements HasShieldPermissions
                                 ->password()
                                 ->required()
                                 ->maxLength(255)
-                                ->default(Str::random(10))
+                                ->default(Str::random(AppHelper::GENERATED_PASSWORD_LENGTH))
                                 ->revealable()
                                 ->dehydrateStateUsing(static fn (?string $state): ?string => filled($state) ? Hash::make($state) : null)
                                 ->required(static fn (Page $livewire): bool => $livewire instanceof CreateUser)
@@ -231,7 +231,7 @@ class UserResource extends Resource implements HasShieldPermissions
                     ->label('Nové heslo')
                     ->required()
                     ->readOnly()
-                    ->default(Str::random(12)),
+                    ->default(Str::random(AppHelper::GENERATED_PASSWORD_LENGTH)),
 
             ])
             ->action(function (User $user, array $data): void {

--- a/app/Http/Controllers/Cron/Jobs/UserSendPassword.php
+++ b/app/Http/Controllers/Cron/Jobs/UserSendPassword.php
@@ -8,13 +8,14 @@ use App\Mail\UserPasswordSend;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 
 class UserSendPassword
 {
     public function sendNewPassword(User $user, ?string $password = null, string $type = UserPasswordSend::ACTION_SEND_PASSWORD): void
     {
         if (is_null($password)) {
-            $password = substr(sha1((string)time()), 0, 10);
+            $password = Str::random(12);
         }
 
         $user->password = Hash::make($password);
@@ -32,7 +33,7 @@ class UserSendPassword
 
         foreach ($users as $user) {
 
-            $password = substr(sha1((string)time()), 0, 10);
+            $password = Str::random(12);
             $user->password = Hash::make($password);
             $user->saveOrFail();
 

--- a/app/Http/Controllers/Cron/Jobs/UserSendPassword.php
+++ b/app/Http/Controllers/Cron/Jobs/UserSendPassword.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Cron\Jobs;
 
 use App\Mail\UserPasswordSend;
 use App\Models\User;
+use App\Shared\Helpers\AppHelper;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
@@ -15,7 +16,7 @@ class UserSendPassword
     public function sendNewPassword(User $user, ?string $password = null, string $type = UserPasswordSend::ACTION_SEND_PASSWORD): void
     {
         if (is_null($password)) {
-            $password = Str::random(12);
+            $password = Str::random(AppHelper::GENERATED_PASSWORD_LENGTH);
         }
 
         $user->password = Hash::make($password);
@@ -33,7 +34,7 @@ class UserSendPassword
 
         foreach ($users as $user) {
 
-            $password = Str::random(12);
+            $password = Str::random(AppHelper::GENERATED_PASSWORD_LENGTH);
             $user->password = Hash::make($password);
             $user->saveOrFail();
 

--- a/app/Shared/Helpers/AppHelper.php
+++ b/app/Shared/Helpers/AppHelper.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Carbon;
 
 final class AppHelper
 {
+    public const int GENERATED_PASSWORD_LENGTH = 12;
+
     public const string DATE_TIME_FORMAT = 'd. m. Y H:i';
 
     public const string DATE_TIME_FULL_FORMAT = 'd. m. Y H:i:s';


### PR DESCRIPTION
sha1() is cryptographically broken and time() as a seed makes generated passwords trivially enumerable. Str::random() uses random_bytes() internally, producing a cryptographically secure result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Temporary and reset passwords are now 12 characters instead of 10, increasing security and complexity.
  * Password generation is now consistent across account provisioning and reset workflows for predictable, uniform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->