### PR TITLE
Replace hardcoded ORIS clubid with config('site-config.club.abbr')

### DIFF
--- a/app/Services/OrisApiService.php
+++ b/app/Services/OrisApiService.php
@@ -346,7 +346,7 @@ final class OrisApiService
     {
         $getParams = [
             'method' => 'getEventEntries',
-            'clubid' => 1, // TODO dej do params
+            'clubid' => config('site-config.club.abbr'),
             'eventid' => $sportEvent->oris_id,
         ];
         $orisResponse = $this->orisGetResponse($getParams);


### PR DESCRIPTION
The hardcoded value 1 would return entries for the wrong club on any deployment. The club abbreviation is already centralised in site-config and the ORIS API accepts it as a valid clubid identifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Event balance retrieval now uses the configured club identifier rather than a fixed default value, enabling proper support for multiple club configurations and improving system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->