### PR TITLE
Fix fatal error on unknown bank code in UpdateBankTransaction

### DIFF
--- a/app/Http/Controllers/Cron/Jobs/UpdateBankTransaction.php
+++ b/app/Http/Controllers/Cron/Jobs/UpdateBankTransaction.php
@@ -13,6 +13,7 @@ use App\Services\Bank\Connector\Transaction;
 use App\Services\Bank\MatchRules\ExtraMembershipFeesRule;
 use App\Shared\Helpers\BankTransactionHelper;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 
 final class UpdateBankTransaction implements CommonCronJobs
 {
@@ -27,6 +28,11 @@ final class UpdateBankTransaction implements CommonCronJobs
                 BankAccount::FIO_BANK => FioBank::class,
                 default => null,
             };
+
+            if ($class === null) {
+                Log::channel('site')->warning("UpdateBankTransaction: unknown bank code '{$bankAccount->code}' for account ID {$bankAccount->id}, skipping.");
+                continue;
+            }
 
             $bankTransactions = (new $class())->getTransactions($bankAccount, $bankAccount->last_synced?->subMinutes(5));
 

--- a/app/Http/Controllers/Cron/Jobs/UpdateBankTransaction.php
+++ b/app/Http/Controllers/Cron/Jobs/UpdateBankTransaction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Cron\Jobs;
 
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 use App\Models\BankAccount;
 use App\Models\BankTransaction;
 use App\Services\Bank\BankAccountService;
@@ -12,8 +14,6 @@ use App\Services\Bank\Connector\MonetaBank;
 use App\Services\Bank\Connector\Transaction;
 use App\Services\Bank\MatchRules\ExtraMembershipFeesRule;
 use App\Shared\Helpers\BankTransactionHelper;
-use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
 
 final class UpdateBankTransaction implements CommonCronJobs
 {


### PR DESCRIPTION
new $class() with null crashes the entire cron job for all accounts. Now skips unrecognised bank codes with a site channel warning so remaining accounts continue to sync normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bank transaction processing to gracefully handle unsupported bank providers, preventing invalid processing attempts for unrecognized accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->