### PR TITLE
Fix Discord webhook silent failure on missing or unknown URL

### DIFF
--- a/app/Http/Controllers/Discord/DiscordWebhookHelper.php
+++ b/app/Http/Controllers/Discord/DiscordWebhookHelper.php
@@ -13,13 +13,14 @@ final class DiscordWebhookHelper extends Controller
     public const string CONTENT_STATUS_UPDATE = 'update';
 
 
-    public static function getWebhookUrl(string $channelName): string
+    public static function getWebhookUrl(string $channelName): ?string
     {
-
-        return match ($channelName) {
+        $url = match ($channelName) {
             self::DISCORD_SPORT_EVENT_WEBHOOK_URL => config('site-config.discord.sport_event.webhook_url'),
             self::DISCORD_CONTENT_WEBHOOK_URL => config('site-config.discord.content.webhook_url'),
-            default => '',
+            default => null,
         };
+
+        return $url !== '' ? $url : null;
     }
 }

--- a/app/Http/Controllers/Discord/RaceEventAddedNotification.php
+++ b/app/Http/Controllers/Discord/RaceEventAddedNotification.php
@@ -10,6 +10,7 @@ use Carbon\Carbon;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 final class RaceEventAddedNotification extends Controller
 {
@@ -22,7 +23,7 @@ final class RaceEventAddedNotification extends Controller
         $this->status = $status;
     }
 
-    public function sendNotification(): PromiseInterface|Response
+    public function sendNotification(): PromiseInterface|Response|null
     {
 
         $raceEventOrisLink = '';
@@ -42,7 +43,14 @@ final class RaceEventAddedNotification extends Controller
             default => '',
         };
 
-        return Http::post(DiscordWebhookHelper::getWebhookUrl(DiscordWebhookHelper::DISCORD_SPORT_EVENT_WEBHOOK_URL), [
+        $url = DiscordWebhookHelper::getWebhookUrl(DiscordWebhookHelper::DISCORD_SPORT_EVENT_WEBHOOK_URL);
+
+        if ($url === null) {
+            Log::channel('site')->warning('RaceEventAddedNotification: Discord webhook URL is not configured, skipping.');
+            return null;
+        }
+
+        return Http::post($url, [
             'content' => $content,
             'embeds' => $embeds,
         ]);

--- a/app/Http/Controllers/Discord/RaceEventCronNotification.php
+++ b/app/Http/Controllers/Discord/RaceEventCronNotification.php
@@ -12,13 +12,14 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 final class RaceEventCronNotification extends Controller
 {
     /**
      * Run one per day
      */
-    public function notification(): PromiseInterface|Response
+    public function notification(): PromiseInterface|Response|null
     {
         $raceEventsToNotify = $this->getRaceEventData();
 
@@ -42,7 +43,14 @@ final class RaceEventCronNotification extends Controller
             }
         }
 
-        return Http::post(DiscordWebhookHelper::getWebhookUrl(DiscordWebhookHelper::DISCORD_CONTENT_WEBHOOK_URL), [
+        $url = DiscordWebhookHelper::getWebhookUrl(DiscordWebhookHelper::DISCORD_CONTENT_WEBHOOK_URL);
+
+        if ($url === null) {
+            Log::channel('site')->warning('RaceEventCronNotification: Discord webhook URL is not configured, skipping.');
+            return null;
+        }
+
+        return Http::post($url, [
             'content' => 'Závody u kterých se blíží termín přihlášek na **první termín**.',
             'embeds' => $embeds,
         ]);


### PR DESCRIPTION
getWebhookUrl() now returns null for unknown channel names and empty URLs. Callers guard against null and log a site channel warning instead of passing an empty string to Http::post() and throwing a Guzzle exception.