### PR TITLE
Add sync mechanism for event start lists and update API endpoints

### DIFF
--- a/app/Console/Commands/OrisSyncStartListCommand.php
+++ b/app/Console/Commands/OrisSyncStartListCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\SportEvent;
+use App\Services\OrisApiService;
+use Illuminate\Console\Command;
+
+class OrisSyncStartListCommand extends Command
+{
+    protected $signature = 'oris:sync-start-list {oris_id : ORIS ID race}';
+
+    protected $description = 'Manually synchronizes the start list from the ORIS API for the specified ORIS race ID';
+
+    public function handle(OrisApiService $orisApiService): int
+    {
+        $orisId = (int) $this->argument('oris_id');
+
+        /** @var SportEvent|null $sportEvent */
+        $sportEvent = SportEvent::query()->where('oris_id', $orisId)->first();
+
+        if ($sportEvent === null) {
+            $this->error("Race  ORIS ID {$orisId} was not found in the database.");
+            return Command::FAILURE;
+        }
+
+        $this->info("I'm syncing the start list for: {$sportEvent->name} (ID: {$sportEvent->id}, ORIS ID: {$orisId})");
+
+        $result = $orisApiService->updateStartList($sportEvent->id);
+
+        if ($result) {
+            $this->info('The start list has been successfully synchronized.');
+            return Command::SUCCESS;
+        }
+
+        $this->error('Synchronization failed — the ORIS API did not return a valid response (the race sheet may not have been published yet).');
+        return Command::FAILURE;
+    }
+}

--- a/app/Console/Commands/OrisSyncStartListCommand.php
+++ b/app/Console/Commands/OrisSyncStartListCommand.php
@@ -22,20 +22,20 @@ class OrisSyncStartListCommand extends Command
         $sportEvent = SportEvent::query()->where('oris_id', $orisId)->first();
 
         if ($sportEvent === null) {
-            $this->error("Race  ORIS ID {$orisId} was not found in the database.");
+            $this->error("Závod s ORIS ID {$orisId} nebyl nalezen v databázi.");
             return Command::FAILURE;
         }
 
-        $this->info("I'm syncing the start list for: {$sportEvent->name} (ID: {$sportEvent->id}, ORIS ID: {$orisId})");
+        $this->info("Synchronizuji startovní listinu: {$sportEvent->name} (ID: {$sportEvent->id}, ORIS ID: {$orisId})");
 
         $result = $orisApiService->updateStartList($sportEvent->id);
 
         if ($result) {
-            $this->info('The start list has been successfully synchronized.');
+            $this->info('Startovní listina byla úspěšně synchronizována.');
             return Command::SUCCESS;
         }
 
-        $this->error('Synchronization failed — the ORIS API did not return a valid response (the race sheet may not have been published yet).');
+        $this->error('Synchronizace selhala — ORIS API nevrátilo platnou odpověď (startovní listina zatím nemusí být zveřejněna).');
         return Command::FAILURE;
     }
 }

--- a/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
+++ b/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
@@ -42,6 +42,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Client\RequestException;
@@ -199,10 +200,6 @@ class EntrySportEvent extends Page implements HasForms, HasTable
                 ->label('Klubová poznámka')
                 ->limit(15)
                 ->tooltip(fn (UserEntry $record): string => $record->club_note ?? ''),
-//            TextColumn::make('requested_start')
-//                ->label('Poznámka')
-//                ->limit(15)
-//                ->tooltip(fn (UserEntry $record): string => $record->requested_start ?? ''),
             TextColumn::make('real_start')
                 ->label('Start v')
                 ->dateTime('H:i')
@@ -228,7 +225,7 @@ class EntrySportEvent extends Page implements HasForms, HasTable
         ];
     }
 
-    public function table(\Filament\Tables\Table $table): \Filament\Tables\Table
+    public function table(Table $table): Table
     {
         return $table->recordClasses('!py-0');
     }

--- a/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
+++ b/app/Filament/Resources/SportEvents/Pages/EntrySportEvent.php
@@ -153,6 +153,21 @@ class EntrySportEvent extends Page implements HasForms, HasTable
         return [
             TextColumn::make('class_name')
                 ->label('Kategorie')
+                ->description(function (UserEntry $record): string {
+                    $sportClass = SportClass::query()
+                        ->where('sport_event_id', $record->sport_event_id)
+                        ->where('name', $record->class_name)
+                        ->first();
+                    if ($sportClass === null) {
+                        return '';
+                    }
+                    $parts = array_filter([
+                        $sportClass->distance ? $sportClass->distance . 'km' : null,
+                        $sportClass->climbing ? $sportClass->climbing . 'm' : null,
+                        $sportClass->controls ? $sportClass->controls . 'k' : null,
+                    ]);
+                    return implode(' | ', $parts);
+                })
                 ->searchable()
                 ->sortable(),
             TextColumn::make('userRaceProfile.UserRaceFullName')
@@ -163,30 +178,35 @@ class EntrySportEvent extends Page implements HasForms, HasTable
                         'profiles' => collect([$record->userRaceProfile])->filter(),
                         'size' => 'text-xs'
                     ])
-                )),
-            TextColumn::make('userRaceProfile.user.name')
-                ->label('Uživatel')
-                ->badge()
-                ->color(static function ($state): string {
-                    if ($state === Auth::user()?->name) {
-                        return 'success';
+                ))
+                ->description(function (UserEntry $record): HtmlString {
+                    $name = $record->userRaceProfile?->user?->name;
+                    if ($name === null) {
+                        return new HtmlString('');
                     }
-
-                    return 'gray';
+                    $isCurrentUser = $name === Auth::user()?->name;
+                    $classes = $isCurrentUser
+                        ? 'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        : 'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+                    return new HtmlString('<span class="' . $classes . '">' . e($name) . '</span>');
                 })
                 ->searchable(),
             TextColumn::make('note')
-                ->label('Poznámka')
+                ->label('Interní poznámka')
                 ->limit(15)
                 ->tooltip(fn (UserEntry $record): string => $record->note ?? ''),
             TextColumn::make('club_note')
                 ->label('Klubová poznámka')
                 ->limit(15)
                 ->tooltip(fn (UserEntry $record): string => $record->club_note ?? ''),
-            TextColumn::make('requested_start')
+//            TextColumn::make('requested_start')
+//                ->label('Poznámka')
+//                ->limit(15)
+//                ->tooltip(fn (UserEntry $record): string => $record->requested_start ?? ''),
+            TextColumn::make('real_start')
                 ->label('Start v')
-                ->limit(15)
-                ->tooltip(fn (UserEntry $record): string => $record->requested_start ?? ''),
+                ->dateTime('H:i')
+                ->placeholder('—'),
             TextColumn::make('rent_si')
                 ->label('Půjčit čip'),
             TextColumn::make('entry_stages')
@@ -201,10 +221,16 @@ class EntrySportEvent extends Page implements HasForms, HasTable
                 ->searchable(),
             TextColumn::make('created_at')
                 ->label('Vytvořeno')
-                ->dateTime(AppHelper::DATE_TIME_FORMAT)
+                ->date('d.m.Y')
+                ->description(fn (UserEntry $record): string => $record->created_at?->format('H:i') ?? '')
                 ->searchable()
                 ->sortable(),
         ];
+    }
+
+    public function table(\Filament\Tables\Table $table): \Filament\Tables\Table
+    {
+        return $table->recordClasses('!py-0');
     }
 
     public function getTableRecordsPerPage(): ?int

--- a/app/Filament/Resources/UserEntries/UserEntryResource.php
+++ b/app/Filament/Resources/UserEntries/UserEntryResource.php
@@ -10,6 +10,7 @@ use Filament\Actions\DeleteBulkAction;
 use App\Filament\Resources\UserEntries\Pages\ListUserEntries;
 use App\Enums\EntryStatus;
 use App\Filament\Resources\UserEntries\InfoList\UserEntryOverview;
+use App\Models\SportClass;
 use App\Models\SportEvent;
 use App\Models\User;
 use App\Models\UserEntry;
@@ -67,6 +68,21 @@ class UserEntryResource extends Resource implements HasShieldPermissions
                     }),
                 TextColumn::make('class_name')
                     ->label('Kategorie')
+                    ->description(function (UserEntry $record): string {
+                        $sportClass = SportClass::query()
+                            ->where('sport_event_id', $record->sport_event_id)
+                            ->where('name', $record->class_name)
+                            ->first();
+                        if ($sportClass === null) {
+                            return '';
+                        }
+                        $parts = array_filter([
+                            $sportClass->distance ? $sportClass->distance . 'km' : null,
+                            $sportClass->climbing ? $sportClass->climbing . 'm' : null,
+                            $sportClass->controls ? $sportClass->controls . 'k' : null,
+                        ]);
+                        return implode(' | ', $parts);
+                    })
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('userRaceProfile.UserRaceFullName')
@@ -76,8 +92,14 @@ class UserEntryResource extends Resource implements HasShieldPermissions
                     ->dateTime(AppHelper::DATE_FORMAT)
                     ->searchable()
                     ->sortable(),
+                TextColumn::make('real_start')
+                    ->label('Start v')
+                    ->dateTime('H:i')
+                    ->placeholder('—'),
                 TextColumn::make('requested_start')
-                    ->label('Start v'),
+                    ->label('Poznámka')
+                    ->limit(20)
+                    ->tooltip(fn (UserEntry $record): string => $record->requested_start ?? ''),
                 IconColumn::make('rent_si')
                     ->label('Půjčít SI')
                     ->icon(fn (int $state): string => match ($state) {

--- a/app/Filament/Resources/UserEntries/UserEntryResource.php
+++ b/app/Filament/Resources/UserEntries/UserEntryResource.php
@@ -10,7 +10,6 @@ use Filament\Actions\DeleteBulkAction;
 use App\Filament\Resources\UserEntries\Pages\ListUserEntries;
 use App\Enums\EntryStatus;
 use App\Filament\Resources\UserEntries\InfoList\UserEntryOverview;
-use App\Models\SportClass;
 use App\Models\SportEvent;
 use App\Models\User;
 use App\Models\UserEntry;
@@ -39,10 +38,10 @@ class UserEntryResource extends Resource implements HasShieldPermissions
     public static function getEloquentQuery(): Builder
     {
         if (Auth::user()?->hasRole('super_admin')) {
-            return UserEntry::query();
+            return UserEntry::query()->with(['sportEvent.sportClasses']);
         } else {
             $userRaceProfilesIds = (new User())->getUserRaceProfilesIds(Auth::user());
-            return UserEntry::query()->whereIn('user_race_profile_id', $userRaceProfilesIds);
+            return UserEntry::query()->with(['sportEvent.sportClasses'])->whereIn('user_race_profile_id', $userRaceProfilesIds);
         }
     }
 
@@ -69,10 +68,7 @@ class UserEntryResource extends Resource implements HasShieldPermissions
                 TextColumn::make('class_name')
                     ->label('Kategorie')
                     ->description(function (UserEntry $record): string {
-                        $sportClass = SportClass::query()
-                            ->where('sport_event_id', $record->sport_event_id)
-                            ->where('name', $record->class_name)
-                            ->first();
+                        $sportClass = $record->sportEvent?->sportClasses->firstWhere('name', $record->class_name);
                         if ($sportClass === null) {
                             return '';
                         }

--- a/app/Http/Components/Oris/OrisResponse.php
+++ b/app/Http/Components/Oris/OrisResponse.php
@@ -18,7 +18,6 @@ use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;

--- a/app/Http/Components/Oris/Response/Entity/StartList.php
+++ b/app/Http/Components/Oris/Response/Entity/StartList.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Components\Oris\Response\Entity;
 
-use Carbon\Carbon;
-
 readonly class StartList
 {
     public function __construct(
@@ -14,13 +12,13 @@ readonly class StartList
         public string $ClassDesc,
         public string $Name,
         public string $RegNo,
-        public string $Lic,
-        public string $ClubNameStartLists,
-        public Carbon|null $StartTime,
-        public string $UserID,
-        public string $ClubID,
-        public string $StartNumber,
-        public string $SI,
+        public ?string $Lic,
+        public ?string $ClubNameStartLists,
+        public ?string $StartTime,
+        public ?string $UserID,
+        public ?string $ClubID,
+        public ?string $StartNumber,
+        public ?string $SI,
     ) {
     }
 }

--- a/app/Http/Controllers/Cron/CommonCron.php
+++ b/app/Http/Controllers/Cron/CommonCron.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Controllers\Cron\Jobs\EntryEndsToPay;
 use App\Http\Controllers\Cron\Jobs\ReportEmailEventWeeklyEndsBySport;
 use App\Http\Controllers\Cron\Jobs\ReportEmailUserDebit;
+use App\Http\Controllers\Cron\Jobs\SyncEventStartLists;
 use App\Http\Controllers\Cron\Jobs\UpdateBankTransaction;
 use App\Http\Controllers\Cron\Jobs\UpdateEvent;
 use App\Http\Controllers\Cron\Jobs\UpdateEventWeather;
@@ -72,6 +73,17 @@ class CommonCron extends Controller
             }
         } catch (Exception $e) {
             Log::channel('site')->warning('ERROR ErrorMessage: '.$e->getMessage());
+        }
+
+        /** @description Sync event start lists from ORIS */
+        try {
+            if ($this->runJob('sync_event_start_lists')) {
+                Log::channel('site')->info('START SyncEventStartLists run cron at '.$this->getActualHour());
+                (new SyncEventStartLists())->run();
+                Log::channel('site')->info('STOP SyncEventStartLists run cron at '.$this->getActualHour());
+            }
+        } catch (Exception $e) {
+            Log::channel('site')->warning('ERROR SyncEventStartLists: '.$e->getMessage());
         }
 
         /** @description Bank Accounts sync */

--- a/app/Http/Controllers/Cron/Jobs/SyncEventStartLists.php
+++ b/app/Http/Controllers/Cron/Jobs/SyncEventStartLists.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Cron\Jobs;
+
+use App\Models\SportEvent;
+use App\Services\OrisApiService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+final class SyncEventStartLists implements CommonCronJobs
+{
+    public function run(): void
+    {
+        $sportEvents = SportEvent::query()
+            ->where('use_oris_for_entries', true)
+            ->whereNotNull('oris_id')
+            ->whereBetween('date', [Carbon::today(), Carbon::today()->addDays(4)])
+            ->whereHas('userEntry', fn ($q) => $q->whereNull('real_start'))
+            ->get();
+
+        foreach ($sportEvents as $sportEvent) {
+            $service = new OrisApiService();
+            $service->updateStartList($sportEvent->id);
+            Log::channel('site')->info('SyncStartList event ID: ' . $sportEvent->id . ' name: ' . $sportEvent->name);
+        }
+    }
+}

--- a/app/Http/Controllers/Cron/Jobs/SyncEventStartLists.php
+++ b/app/Http/Controllers/Cron/Jobs/SyncEventStartLists.php
@@ -20,10 +20,14 @@ final class SyncEventStartLists implements CommonCronJobs
             ->whereHas('userEntry', fn ($q) => $q->whereNull('real_start'))
             ->get();
 
+        $service = new OrisApiService();
         foreach ($sportEvents as $sportEvent) {
-            $service = new OrisApiService();
-            $service->updateStartList($sportEvent->id);
-            Log::channel('site')->info('SyncStartList event ID: ' . $sportEvent->id . ' name: ' . $sportEvent->name);
+            try {
+                $service->updateStartList($sportEvent->id);
+                Log::channel('site')->info('SyncStartList event ID: ' . $sportEvent->id . ' name: ' . $sportEvent->name);
+            } catch (\Throwable $e) {
+                Log::channel('site')->warning('SyncStartList failed for event ID ' . $sportEvent->id . ' name: ' . $sportEvent->name . ': ' . $e->getMessage());
+            }
         }
     }
 }

--- a/app/Services/OrisApiService.php
+++ b/app/Services/OrisApiService.php
@@ -81,10 +81,6 @@ final class OrisApiService
                 continue;
             }
 
-            //            if($startEntry->RegNo === 'ABM7210') {
-            //                dd($raceProfile);
-            //            }
-
             UserEntry::query()
                 ->where('sport_event_id', $sportEventId)
                 ->where('user_race_profile_id', $raceProfile->id)
@@ -105,9 +101,8 @@ final class OrisApiService
         ];
         $orisResponse = $this->orisGetResponse($getParams);
 
-        $event = new OrisMethod();
-        if ($event->checkOrisResponse($orisResponse)) {
-            $orisData = $event->data($orisResponse);
+        if ($this->orisMethod->checkOrisResponse($orisResponse)) {
+            $orisData = $this->orisMethod->data($orisResponse);
 
             // Create|Update Event
             /** @var SportEvent $eventModel */
@@ -180,7 +175,7 @@ final class OrisApiService
             $eventModel->saveOrFail();
 
             // Create|Update Classes
-            $classes = $event->classes($orisResponse);
+            $classes = $this->orisMethod->classes($orisResponse);
             foreach ($classes as $class) {
                 $classModel = SportClass::query()
                     ->where('sport_event_id', '=', $eventModel->id)
@@ -213,7 +208,7 @@ final class OrisApiService
             }
 
             // Create|Update Services
-            $services = $event->services($orisResponse);
+            $services = $this->orisMethod->services($orisResponse);
             foreach ($services as $service) {
                 /** @var SportService $serviceModel */
                 $serviceModel = SportService::query()
@@ -236,8 +231,8 @@ final class OrisApiService
             }
 
             // Create|Update Links
-            $documents = $event->documents($orisResponse);
-            $links = $event->links($orisResponse);
+            $documents = $this->orisMethod->documents($orisResponse);
+            $links = $this->orisMethod->links($orisResponse);
 
             $activeLinksDocumentsIds = [];
             foreach ($documents as $document) {
@@ -251,13 +246,13 @@ final class OrisApiService
             $this->clearOldLinksDocuments($activeLinksDocumentsIds, $eventModel);
 
             // Create|Update locations alias markers
-            $markers = $event->locations($orisResponse);
+            $markers = $this->orisMethod->locations($orisResponse);
             $this->updateMarkers($markers, $eventModel);
 
             /**
              * @description Create|Update SportEventNews
              */
-            $news = $event->news($orisResponse);
+            $news = $this->orisMethod->news($orisResponse);
             $this->updateNews($news, $eventModel);
 
         }

--- a/app/Services/OrisApiService.php
+++ b/app/Services/OrisApiService.php
@@ -26,6 +26,7 @@ use App\Models\SportService;
 use App\Models\User;
 use App\Models\UserCredit;
 use App\Models\UserCreditNote;
+use App\Models\UserEntry;
 use App\Models\UserRaceProfile;
 use App\Shared\Helpers\AppHelper;
 use App\Shared\Helpers\EmptyType;
@@ -55,24 +56,42 @@ final class OrisApiService
         $this->orisMethod = $orisMethod ?? new OrisMethod();
     }
 
-    //getEventStartLists
-    public function updateStartList(int $eventId): bool
+    public function updateStartList(int $sportEventId): bool
     {
-        $getParams = [
-            'method' => 'getEvent',
-            'id' => $eventId,
-        ];
+        $sportEvent = SportEvent::query()->find($sportEventId);
+        if ($sportEvent === null || $sportEvent->oris_id === null) {
+            return false;
+        }
 
-        $orisResponse = $this->orisGetResponse($getParams);
+        $orisResponse = $this->orisGetResponse([
+            'method' => 'getEventStartLists',
+            'eventid' => $sportEvent->oris_id,
+        ]);
 
-        $startList = new OrisMethod();
+        if (! $this->orisMethod->checkOrisResponse($orisResponse)) {
+            return false;
+        }
 
-        if ($startList->checkOrisResponse($orisResponse)) {
-            $orisData = $startList->data($orisResponse);
+        foreach ($this->orisMethod->startList($orisResponse) as $startEntry) {
+            $raceProfile = UserRaceProfile::query()
+                ->where('reg_number', $startEntry->RegNo)
+                ->first();
+
+            if ($raceProfile === null) {
+                continue;
+            }
+
+            //            if($startEntry->RegNo === 'ABM7210') {
+            //                dd($raceProfile);
+            //            }
+
+            UserEntry::query()
+                ->where('sport_event_id', $sportEventId)
+                ->where('user_race_profile_id', $raceProfile->id)
+                ->update(['real_start' => $startEntry->StartTime !== null ? Carbon::parse($startEntry->StartTime) : null]);
         }
 
         return true;
-
     }
 
     /**
@@ -187,6 +206,7 @@ final class OrisApiService
                 $classModel->class_definition_id = $classDefinitionModel->id;
                 $classModel->name = $class->Name;
                 $classModel->distance = $class->Distance;
+                $classModel->climbing = $class->Climbing;
                 $classModel->controls = $class->Controls;
                 $classModel->fee = (float) $class->Fee;
                 $classModel->saveOrFail();

--- a/config/site-config.php
+++ b/config/site-config.php
@@ -147,6 +147,13 @@ return [
             'months' => ['*'],
             'days_in_week' => ['*'],
         ],
+        'sync_event_start_lists' => [
+            'active' => true,
+            'hours' => ['20'],
+            'days_in_month' => ['*'],
+            'months' => ['*'],
+            'days_in_week' => ['*'],
+        ],
     ],
 
     'cron_url_key' => env('CRON_URL_KEY', 'cron_url_key'),

--- a/resources/views/filament/resources/sport-event-resource/pages/event-entry.blade.php
+++ b/resources/views/filament/resources/sport-event-resource/pages/event-entry.blade.php
@@ -286,7 +286,12 @@
                     <div class="mb-10">
                         <div class="app-front-content">
 
-                            @if(count($record->sportEventNews()->get()) > 0)
+                            @php
+                                $allNews = $record->sportEventNews()->orderByDesc('date')->get();
+                                $visibleNews = $allNews->take(6);
+                                $hiddenNews = $allNews->skip(6);
+                            @endphp
+                            @if($allNews->isNotEmpty())
                                 <h4 class="flex items-center mb-4 text-lg font-medium text-gray-900 dark:text-white">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                                          stroke-width="1.5" stroke="currentColor"
@@ -296,15 +301,37 @@
                                     </svg>
                                     Rychlé novinky
                                 </h4>
-                                <dl class="text-gray-900 divide-y divide-gray-200 dark:text-white dark:divide-gray-700">
-                                    @foreach($record->sportEventNews()->get() as $quickNews)
-                                        <div class="flex flex-col pb-2">
-                                            <dt class="mb-1 text-gray-500 dark:text-gray-400 font-light">{{ Carbon::parse($quickNews->date)->format(AppHelper::DATE_TIME_FORMAT) }}</dt>
-                                            <dd class="font-normal">{{ html_entity_decode($quickNews->text) }}</dd>
-                                        </div>
-                                    @endforeach
-                                </dl>
-                                <hr>
+                                <div x-data="{ expanded: false }">
+                                    <dl class="text-gray-900 divide-y divide-gray-200 dark:text-white dark:divide-gray-700">
+                                        @foreach($visibleNews as $quickNews)
+                                            <div class="flex flex-col pb-2">
+                                                <dt class="mb-1 text-gray-500 dark:text-gray-400 font-light">{{ Carbon::parse($quickNews->date)->format(AppHelper::DATE_TIME_FORMAT) }}</dt>
+                                                <dd class="font-normal">{{ html_entity_decode($quickNews->text) }}</dd>
+                                            </div>
+                                        @endforeach
+                                        @if($hiddenNews->isNotEmpty())
+                                            <template x-if="expanded">
+                                                <div>
+                                                    @foreach($hiddenNews as $quickNews)
+                                                        <div class="flex flex-col pb-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+                                                            <dt class="mb-1 text-gray-500 dark:text-gray-400 font-light">{{ Carbon::parse($quickNews->date)->format(AppHelper::DATE_TIME_FORMAT) }}</dt>
+                                                            <dd class="font-normal">{{ html_entity_decode($quickNews->text) }}</dd>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </template>
+                                        @endif
+                                    </dl>
+                                    @if($hiddenNews->isNotEmpty())
+                                        <button
+                                            type="button"
+                                            x-on:click="expanded = !expanded"
+                                            class="mt-2 text-sm text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300 font-medium">
+                                            <span x-show="!expanded">Zobrazit další novinky ({{ $hiddenNews->count() }})</span>
+                                            <span x-show="expanded">Skrýt</span>
+                                        </button>
+                                    @endif
+                                </div>
                             @endif
 
                             <h4 class="flex items-center mb-4 text-lg font-medium text-gray-900 dark:text-white">

--- a/resources/views/scribe/index.blade.php
+++ b/resources/views/scribe/index.blade.php
@@ -77,14 +77,14 @@
                                 <a href="#v1-user">USER</a>
                             </li>
                                                             <ul id="tocify-subheader-v1-user" class="tocify-subheader">
-                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-user-raceProfiles">
-                                            <a href="#v1-GETapi-v1-user-raceProfiles">GET api/v1/user/raceProfiles</a>
+                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-user-race-profiles">
+                                            <a href="#v1-GETapi-v1-user-race-profiles">GET api/v1/user/race-profiles</a>
                                         </li>
                                                                             <li class="tocify-item level-3" data-unique="v1-GETapi-v1-user-entry">
                                             <a href="#v1-GETapi-v1-user-entry">GET api/v1/user/entry</a>
                                         </li>
-                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-user-creditBalance">
-                                            <a href="#v1-GETapi-v1-user-creditBalance">GET api/v1/user/creditBalance</a>
+                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-user-credit-balance">
+                                            <a href="#v1-GETapi-v1-user-credit-balance">GET api/v1/user/credit-balance</a>
                                         </li>
                                                                     </ul>
                                                                                 <li class="tocify-item level-2" data-unique="v1-post">
@@ -113,8 +113,8 @@
                                 <a href="#v1-sport-event">SPORT EVENT</a>
                             </li>
                                                             <ul id="tocify-subheader-v1-sport-event" class="tocify-subheader">
-                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-sportEvent">
-                                            <a href="#v1-GETapi-v1-sportEvent">GET api/v1/sportEvent</a>
+                                                                            <li class="tocify-item level-3" data-unique="v1-GETapi-v1-sport-event">
+                                            <a href="#v1-GETapi-v1-sport-event">GET api/v1/sport-event</a>
                                         </li>
                                                                     </ul>
                                                                         </ul>
@@ -156,20 +156,20 @@ You can switch the language used with the tabs at the top right (or from the nav
                                         <p>
                     <p>Authenticated user overview endpoints</p>
                 </p>
-                                        <h2 id="v1-GETapi-v1-user-raceProfiles">GET api/v1/user/raceProfiles</h2>
+                                        <h2 id="v1-GETapi-v1-user-race-profiles">GET api/v1/user/race-profiles</h2>
 
 <p>
 </p>
 
 
 
-<span id="example-requests-GETapi-v1-user-raceProfiles">
+<span id="example-requests-GETapi-v1-user-race-profiles">
 <blockquote>Example request:</blockquote>
 
 
 <div class="php-example">
     <pre><code class="language-php">$client = new \GuzzleHttp\Client();
-$url = 'http://localhost/api/v1/user/raceProfiles';
+$url = 'http://localhost/api/v1/user/race-profiles';
 $response = $client-&gt;get(
     $url,
     [
@@ -188,14 +188,14 @@ print_r(json_decode((string) $body));</code></pre></div>
 
 <div class="bash-example">
     <pre><code class="language-bash">curl --request GET \
-    --get "http://localhost/api/v1/user/raceProfiles?all=" \
+    --get "http://localhost/api/v1/user/race-profiles?all=" \
     --header "Content-Type: application/json" \
     --header "Accept: application/json"</code></pre></div>
 
 
 <div class="javascript-example">
     <pre><code class="language-javascript">const url = new URL(
-    "http://localhost/api/v1/user/raceProfiles"
+    "http://localhost/api/v1/user/race-profiles"
 );
 
 const params = {
@@ -217,7 +217,7 @@ fetch(url, {
 
 </span>
 
-<span id="example-responses-GETapi-v1-user-raceProfiles">
+<span id="example-responses-GETapi-v1-user-race-profiles">
             <blockquote>
             <p>Example response (200, Example User Race Profiles):</p>
         </blockquote>
@@ -257,43 +257,43 @@ fetch(url, {
 }</code>
  </pre>
     </span>
-<span id="execution-results-GETapi-v1-user-raceProfiles" hidden>
+<span id="execution-results-GETapi-v1-user-race-profiles" hidden>
     <blockquote>Received response<span
-                id="execution-response-status-GETapi-v1-user-raceProfiles"></span>:
+                id="execution-response-status-GETapi-v1-user-race-profiles"></span>:
     </blockquote>
-    <pre class="json"><code id="execution-response-content-GETapi-v1-user-raceProfiles"
+    <pre class="json"><code id="execution-response-content-GETapi-v1-user-race-profiles"
       data-empty-response-text="<Empty response>" style="max-height: 400px;"></code></pre>
 </span>
-<span id="execution-error-GETapi-v1-user-raceProfiles" hidden>
+<span id="execution-error-GETapi-v1-user-race-profiles" hidden>
     <blockquote>Request failed with error:</blockquote>
-    <pre><code id="execution-error-message-GETapi-v1-user-raceProfiles">
+    <pre><code id="execution-error-message-GETapi-v1-user-race-profiles">
 
 Tip: Check that you&#039;re properly connected to the network.
 If you&#039;re a maintainer of this API, verify that your API is running and you&#039;ve enabled CORS.
 You can check the Dev Tools console for debugging information.</code></pre>
 </span>
-<form id="form-GETapi-v1-user-raceProfiles" data-method="GET"
-      data-path="api/v1/user/raceProfiles"
+<form id="form-GETapi-v1-user-race-profiles" data-method="GET"
+      data-path="api/v1/user/race-profiles"
       data-authed="0"
       data-hasfiles="0"
       data-isarraybody="0"
       autocomplete="off"
-      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-user-raceProfiles', this);">
+      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-user-race-profiles', this);">
     <h3>
         Request&nbsp;&nbsp;&nbsp;
                     <button type="button"
                     style="background-color: #8fbcd4; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-tryout-GETapi-v1-user-raceProfiles"
-                    onclick="tryItOut('GETapi-v1-user-raceProfiles');">Try it out ⚡
+                    id="btn-tryout-GETapi-v1-user-race-profiles"
+                    onclick="tryItOut('GETapi-v1-user-race-profiles');">Try it out ⚡
             </button>
             <button type="button"
                     style="background-color: #c97a7e; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-canceltryout-GETapi-v1-user-raceProfiles"
-                    onclick="cancelTryOut('GETapi-v1-user-raceProfiles');" hidden>Cancel 🛑
+                    id="btn-canceltryout-GETapi-v1-user-race-profiles"
+                    onclick="cancelTryOut('GETapi-v1-user-race-profiles');" hidden>Cancel 🛑
             </button>&nbsp;&nbsp;
             <button type="submit"
                     style="background-color: #6ac174; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-executetryout-GETapi-v1-user-raceProfiles"
+                    id="btn-executetryout-GETapi-v1-user-race-profiles"
                     data-initial-text="Send Request 💥"
                     data-loading-text="⏱ Sending..."
                     hidden>Send Request 💥
@@ -301,7 +301,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
             </h3>
             <p>
             <small class="badge badge-green">GET</small>
-            <b><code>api/v1/user/raceProfiles</code></b>
+            <b><code>api/v1/user/race-profiles</code></b>
         </p>
                 <h4 class="fancy-heading-panel"><b>Headers</b></h4>
                                 <div style="padding-left: 28px; clear: unset;">
@@ -310,7 +310,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Content-Type"                data-endpoint="GETapi-v1-user-raceProfiles"
+                              name="Content-Type"                data-endpoint="GETapi-v1-user-race-profiles"
                value="application/json"
                data-component="header">
     <br>
@@ -322,7 +322,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Accept"                data-endpoint="GETapi-v1-user-raceProfiles"
+                              name="Accept"                data-endpoint="GETapi-v1-user-race-profiles"
                value="application/json"
                data-component="header">
     <br>
@@ -334,17 +334,17 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <small>boolean</small>&nbsp;
 <i>optional</i> &nbsp;
  &nbsp;
-                <label data-endpoint="GETapi-v1-user-raceProfiles" style="display: none">
+                <label data-endpoint="GETapi-v1-user-race-profiles" style="display: none">
             <input type="radio" name="all"
                    value="1"
-                   data-endpoint="GETapi-v1-user-raceProfiles"
+                   data-endpoint="GETapi-v1-user-race-profiles"
                    data-component="query"             >
             <code>true</code>
         </label>
-        <label data-endpoint="GETapi-v1-user-raceProfiles" style="display: none">
+        <label data-endpoint="GETapi-v1-user-race-profiles" style="display: none">
             <input type="radio" name="all"
                    value="0"
-                   data-endpoint="GETapi-v1-user-raceProfiles"
+                   data-endpoint="GETapi-v1-user-race-profiles"
                    data-component="query"             >
             <code>false</code>
         </label>
@@ -644,20 +644,20 @@ You can check the Dev Tools console for debugging information.</code></pre>
         </div>
         </form>
 
-                    <h2 id="v1-GETapi-v1-user-creditBalance">GET api/v1/user/creditBalance</h2>
+                    <h2 id="v1-GETapi-v1-user-credit-balance">GET api/v1/user/credit-balance</h2>
 
 <p>
 </p>
 
 
 
-<span id="example-requests-GETapi-v1-user-creditBalance">
+<span id="example-requests-GETapi-v1-user-credit-balance">
 <blockquote>Example request:</blockquote>
 
 
 <div class="php-example">
     <pre><code class="language-php">$client = new \GuzzleHttp\Client();
-$url = 'http://localhost/api/v1/user/creditBalance';
+$url = 'http://localhost/api/v1/user/credit-balance';
 $response = $client-&gt;get(
     $url,
     [
@@ -673,14 +673,14 @@ print_r(json_decode((string) $body));</code></pre></div>
 
 <div class="bash-example">
     <pre><code class="language-bash">curl --request GET \
-    --get "http://localhost/api/v1/user/creditBalance" \
+    --get "http://localhost/api/v1/user/credit-balance" \
     --header "Content-Type: application/json" \
     --header "Accept: application/json"</code></pre></div>
 
 
 <div class="javascript-example">
     <pre><code class="language-javascript">const url = new URL(
-    "http://localhost/api/v1/user/creditBalance"
+    "http://localhost/api/v1/user/credit-balance"
 );
 
 const headers = {
@@ -696,7 +696,7 @@ fetch(url, {
 
 </span>
 
-<span id="example-responses-GETapi-v1-user-creditBalance">
+<span id="example-responses-GETapi-v1-user-credit-balance">
             <blockquote>
             <p>Example response (200, Example User Credit Balance):</p>
         </blockquote>
@@ -712,43 +712,43 @@ fetch(url, {
 }</code>
  </pre>
     </span>
-<span id="execution-results-GETapi-v1-user-creditBalance" hidden>
+<span id="execution-results-GETapi-v1-user-credit-balance" hidden>
     <blockquote>Received response<span
-                id="execution-response-status-GETapi-v1-user-creditBalance"></span>:
+                id="execution-response-status-GETapi-v1-user-credit-balance"></span>:
     </blockquote>
-    <pre class="json"><code id="execution-response-content-GETapi-v1-user-creditBalance"
+    <pre class="json"><code id="execution-response-content-GETapi-v1-user-credit-balance"
       data-empty-response-text="<Empty response>" style="max-height: 400px;"></code></pre>
 </span>
-<span id="execution-error-GETapi-v1-user-creditBalance" hidden>
+<span id="execution-error-GETapi-v1-user-credit-balance" hidden>
     <blockquote>Request failed with error:</blockquote>
-    <pre><code id="execution-error-message-GETapi-v1-user-creditBalance">
+    <pre><code id="execution-error-message-GETapi-v1-user-credit-balance">
 
 Tip: Check that you&#039;re properly connected to the network.
 If you&#039;re a maintainer of this API, verify that your API is running and you&#039;ve enabled CORS.
 You can check the Dev Tools console for debugging information.</code></pre>
 </span>
-<form id="form-GETapi-v1-user-creditBalance" data-method="GET"
-      data-path="api/v1/user/creditBalance"
+<form id="form-GETapi-v1-user-credit-balance" data-method="GET"
+      data-path="api/v1/user/credit-balance"
       data-authed="0"
       data-hasfiles="0"
       data-isarraybody="0"
       autocomplete="off"
-      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-user-creditBalance', this);">
+      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-user-credit-balance', this);">
     <h3>
         Request&nbsp;&nbsp;&nbsp;
                     <button type="button"
                     style="background-color: #8fbcd4; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-tryout-GETapi-v1-user-creditBalance"
-                    onclick="tryItOut('GETapi-v1-user-creditBalance');">Try it out ⚡
+                    id="btn-tryout-GETapi-v1-user-credit-balance"
+                    onclick="tryItOut('GETapi-v1-user-credit-balance');">Try it out ⚡
             </button>
             <button type="button"
                     style="background-color: #c97a7e; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-canceltryout-GETapi-v1-user-creditBalance"
-                    onclick="cancelTryOut('GETapi-v1-user-creditBalance');" hidden>Cancel 🛑
+                    id="btn-canceltryout-GETapi-v1-user-credit-balance"
+                    onclick="cancelTryOut('GETapi-v1-user-credit-balance');" hidden>Cancel 🛑
             </button>&nbsp;&nbsp;
             <button type="submit"
                     style="background-color: #6ac174; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-executetryout-GETapi-v1-user-creditBalance"
+                    id="btn-executetryout-GETapi-v1-user-credit-balance"
                     data-initial-text="Send Request 💥"
                     data-loading-text="⏱ Sending..."
                     hidden>Send Request 💥
@@ -756,7 +756,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
             </h3>
             <p>
             <small class="badge badge-green">GET</small>
-            <b><code>api/v1/user/creditBalance</code></b>
+            <b><code>api/v1/user/credit-balance</code></b>
         </p>
                 <h4 class="fancy-heading-panel"><b>Headers</b></h4>
                                 <div style="padding-left: 28px; clear: unset;">
@@ -765,7 +765,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Content-Type"                data-endpoint="GETapi-v1-user-creditBalance"
+                              name="Content-Type"                data-endpoint="GETapi-v1-user-credit-balance"
                value="application/json"
                data-component="header">
     <br>
@@ -777,7 +777,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Accept"                data-endpoint="GETapi-v1-user-creditBalance"
+                              name="Accept"                data-endpoint="GETapi-v1-user-credit-balance"
                value="application/json"
                data-component="header">
     <br>
@@ -1721,20 +1721,20 @@ You can check the Dev Tools console for debugging information.</code></pre>
                                         <p>
                     <p>Sport events and event category options</p>
                 </p>
-                                        <h2 id="v1-GETapi-v1-sportEvent">GET api/v1/sportEvent</h2>
+                                        <h2 id="v1-GETapi-v1-sport-event">GET api/v1/sport-event</h2>
 
 <p>
 </p>
 
 
 
-<span id="example-requests-GETapi-v1-sportEvent">
+<span id="example-requests-GETapi-v1-sport-event">
 <blockquote>Example request:</blockquote>
 
 
 <div class="php-example">
     <pre><code class="language-php">$client = new \GuzzleHttp\Client();
-$url = 'http://localhost/api/v1/sportEvent';
+$url = 'http://localhost/api/v1/sport-event';
 $response = $client-&gt;get(
     $url,
     [
@@ -1764,7 +1764,7 @@ print_r(json_decode((string) $body));</code></pre></div>
 
 <div class="bash-example">
     <pre><code class="language-bash">curl --request GET \
-    --get "http://localhost/api/v1/sportEvent?from=2026-01-01&amp;to=2026-12-31&amp;event_type=race&amp;class_definition_id=15&amp;page=1&amp;per_page=20" \
+    --get "http://localhost/api/v1/sport-event?from=2026-01-01&amp;to=2026-12-31&amp;event_type=race&amp;class_definition_id=15&amp;page=1&amp;per_page=20" \
     --header "Content-Type: application/json" \
     --header "Accept: application/json" \
     --data "{
@@ -1778,7 +1778,7 @@ print_r(json_decode((string) $body));</code></pre></div>
 
 <div class="javascript-example">
     <pre><code class="language-javascript">const url = new URL(
-    "http://localhost/api/v1/sportEvent"
+    "http://localhost/api/v1/sport-event"
 );
 
 const params = {
@@ -1812,7 +1812,7 @@ fetch(url, {
 
 </span>
 
-<span id="example-responses-GETapi-v1-sportEvent">
+<span id="example-responses-GETapi-v1-sport-event">
             <blockquote>
             <p>Example response (200, Example Sport Event List):</p>
         </blockquote>
@@ -1870,43 +1870,43 @@ fetch(url, {
 }</code>
  </pre>
     </span>
-<span id="execution-results-GETapi-v1-sportEvent" hidden>
+<span id="execution-results-GETapi-v1-sport-event" hidden>
     <blockquote>Received response<span
-                id="execution-response-status-GETapi-v1-sportEvent"></span>:
+                id="execution-response-status-GETapi-v1-sport-event"></span>:
     </blockquote>
-    <pre class="json"><code id="execution-response-content-GETapi-v1-sportEvent"
+    <pre class="json"><code id="execution-response-content-GETapi-v1-sport-event"
       data-empty-response-text="<Empty response>" style="max-height: 400px;"></code></pre>
 </span>
-<span id="execution-error-GETapi-v1-sportEvent" hidden>
+<span id="execution-error-GETapi-v1-sport-event" hidden>
     <blockquote>Request failed with error:</blockquote>
-    <pre><code id="execution-error-message-GETapi-v1-sportEvent">
+    <pre><code id="execution-error-message-GETapi-v1-sport-event">
 
 Tip: Check that you&#039;re properly connected to the network.
 If you&#039;re a maintainer of this API, verify that your API is running and you&#039;ve enabled CORS.
 You can check the Dev Tools console for debugging information.</code></pre>
 </span>
-<form id="form-GETapi-v1-sportEvent" data-method="GET"
-      data-path="api/v1/sportEvent"
+<form id="form-GETapi-v1-sport-event" data-method="GET"
+      data-path="api/v1/sport-event"
       data-authed="0"
       data-hasfiles="0"
       data-isarraybody="0"
       autocomplete="off"
-      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-sportEvent', this);">
+      onsubmit="event.preventDefault(); executeTryOut('GETapi-v1-sport-event', this);">
     <h3>
         Request&nbsp;&nbsp;&nbsp;
                     <button type="button"
                     style="background-color: #8fbcd4; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-tryout-GETapi-v1-sportEvent"
-                    onclick="tryItOut('GETapi-v1-sportEvent');">Try it out ⚡
+                    id="btn-tryout-GETapi-v1-sport-event"
+                    onclick="tryItOut('GETapi-v1-sport-event');">Try it out ⚡
             </button>
             <button type="button"
                     style="background-color: #c97a7e; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-canceltryout-GETapi-v1-sportEvent"
-                    onclick="cancelTryOut('GETapi-v1-sportEvent');" hidden>Cancel 🛑
+                    id="btn-canceltryout-GETapi-v1-sport-event"
+                    onclick="cancelTryOut('GETapi-v1-sport-event');" hidden>Cancel 🛑
             </button>&nbsp;&nbsp;
             <button type="submit"
                     style="background-color: #6ac174; padding: 5px 10px; border-radius: 5px; border-width: thin;"
-                    id="btn-executetryout-GETapi-v1-sportEvent"
+                    id="btn-executetryout-GETapi-v1-sport-event"
                     data-initial-text="Send Request 💥"
                     data-loading-text="⏱ Sending..."
                     hidden>Send Request 💥
@@ -1914,7 +1914,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
             </h3>
             <p>
             <small class="badge badge-green">GET</small>
-            <b><code>api/v1/sportEvent</code></b>
+            <b><code>api/v1/sport-event</code></b>
         </p>
                 <h4 class="fancy-heading-panel"><b>Headers</b></h4>
                                 <div style="padding-left: 28px; clear: unset;">
@@ -1923,7 +1923,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Content-Type"                data-endpoint="GETapi-v1-sportEvent"
+                              name="Content-Type"                data-endpoint="GETapi-v1-sport-event"
                value="application/json"
                data-component="header">
     <br>
@@ -1935,7 +1935,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="Accept"                data-endpoint="GETapi-v1-sportEvent"
+                              name="Accept"                data-endpoint="GETapi-v1-sport-event"
                value="application/json"
                data-component="header">
     <br>
@@ -1948,7 +1948,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="from"                data-endpoint="GETapi-v1-sportEvent"
+                              name="from"                data-endpoint="GETapi-v1-sport-event"
                value="2026-01-01"
                data-component="query">
     <br>
@@ -1960,7 +1960,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="to"                data-endpoint="GETapi-v1-sportEvent"
+                              name="to"                data-endpoint="GETapi-v1-sport-event"
                value="2026-12-31"
                data-component="query">
     <br>
@@ -1972,7 +1972,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="event_type"                data-endpoint="GETapi-v1-sportEvent"
+                              name="event_type"                data-endpoint="GETapi-v1-sport-event"
                value="race"
                data-component="query">
     <br>
@@ -1984,7 +1984,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="number" style="display: none"
-               step="any"               name="class_definition_id"                data-endpoint="GETapi-v1-sportEvent"
+               step="any"               name="class_definition_id"                data-endpoint="GETapi-v1-sport-event"
                value="15"
                data-component="query">
     <br>
@@ -1996,7 +1996,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="number" style="display: none"
-               step="any"               name="page"                data-endpoint="GETapi-v1-sportEvent"
+               step="any"               name="page"                data-endpoint="GETapi-v1-sport-event"
                value="1"
                data-component="query">
     <br>
@@ -2008,7 +2008,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="number" style="display: none"
-               step="any"               name="per_page"                data-endpoint="GETapi-v1-sportEvent"
+               step="any"               name="per_page"                data-endpoint="GETapi-v1-sport-event"
                value="20"
                data-component="query">
     <br>
@@ -2021,7 +2021,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="from"                data-endpoint="GETapi-v1-sportEvent"
+                              name="from"                data-endpoint="GETapi-v1-sport-event"
                value="2026-04-17"
                data-component="body">
     <br>
@@ -2033,7 +2033,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="to"                data-endpoint="GETapi-v1-sportEvent"
+                              name="to"                data-endpoint="GETapi-v1-sport-event"
                value="2026-04-17"
                data-component="body">
     <br>
@@ -2045,7 +2045,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="text" style="display: none"
-                              name="event_type"                data-endpoint="GETapi-v1-sportEvent"
+                              name="event_type"                data-endpoint="GETapi-v1-sport-event"
                value=""
                data-component="body">
     <br>
@@ -2057,7 +2057,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="number" style="display: none"
-               step="any"               name="class_definition_id"                data-endpoint="GETapi-v1-sportEvent"
+               step="any"               name="class_definition_id"                data-endpoint="GETapi-v1-sport-event"
                value="16"
                data-component="body">
     <br>
@@ -2069,7 +2069,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <i>optional</i> &nbsp;
  &nbsp;
                 <input type="number" style="display: none"
-               step="any"               name="per_page"                data-endpoint="GETapi-v1-sportEvent"
+               step="any"               name="per_page"                data-endpoint="GETapi-v1-sport-event"
                value="22"
                data-component="body">
     <br>


### PR DESCRIPTION
- Introduced a cron job to sync event start lists from ORIS.
- Updated `OrisApiService` to handle start list syncing functionality.
- Adjusted API endpoint naming conventions to use kebab-case for consistency.
- Enhanced `StartList` entity to allow nullable fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic hourly synchronization of race start lists from ORIS API
  * Display of actual race start times in entry management
  * Race class details (distance, climbing, controls) now visible in entry listings

* **Improvements**
  * Enhanced entry pages with improved data organization and layout
  * Event news list now expandable for cleaner presentation
  
* **Chores**
  * Updated API documentation routing paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->