### PR TITLE
Add pre-race summary email functionality

### DIFF
--- a/.claude/plans/pre-race-summary-email.md
+++ b/.claude/plans/pre-race-summary-email.md
@@ -1,0 +1,160 @@
+# DEV-9: Přidat mail souhrn před závodem
+
+**Notion:** https://www.notion.so/345bdf3f680c805baf33cd177f276bc1  
+**Status:** Analysis
+
+## Cíl
+
+Umožnit uživatelům obdržet den (nebo X dní) před závodem e-mail se souhrnnými informacemi o nadcházejícím závodě a jejich přihláškách.
+
+---
+
+## Datový tok
+
+1. Scheduler spustí job každou hodinu
+2. Job najde závody, jejichž `date` je za `days_before` dní
+3. Pro každý takový závod najde uživatele s přihláškami (`UserEntry`)
+4. Zkontroluje, zda má uživatel v `UserSetting` (type='mail') povoleno `pre_race_summary_enabled = true`
+5. Zkontroluje, zda aktuální hodina odpovídá `pre_race_summary_time_trigger`
+6. Pokud ano, zašle `PreRaceSummaryMail`
+
+---
+
+## Struktura e-mailu
+
+### Sekce 1 – Informace o akci
+- Název akce (`sport_events.name`)
+- Datum konání + datum konce (`date`, `date_end`) + počet dní
+- Čas startu první etapy (`start_time`)
+- Odkaz na ORIS (`oris_id` → `https://oris.orientacnisporty.cz/Zavod?id={oris_id}`)
+
+### Sekce 2 – Závodní profily (přihlášení účastníci)
+Jeden řádek na každý `UserEntry`:
+- Registrační číslo (`user_race_profiles.reg_number`)
+- Jméno a příjmení (`first_name`, `last_name`)
+- Kategorie (`user_entries.class_name`)
+- Startovní čas přímo hodnota (`real_start`), relativní čás (počet minut mezi `real_start` - `start_time`)
+- Parametry kategorie ze `sport_classes`: vzdálenost, počet kontrol, převýšení
+
+### Sekce 3 – Popis akce *(pouze pokud `event_info` není null)*
+- `sport_events.event_info`
+
+### Sekce 4 – Linky *(pouze pokud existují záznamy)*
+- `sport_event_links`: `name_cz` + `source_url`
+
+### Sekce 5 – Novinky *(pouze pokud existují záznamy)*
+- Posledních 5 záznamů z `sport_event_news` (seřazeno `date DESC`)
+
+---
+
+## Co je potřeba vytvořit
+
+### 1. `app/Mail/PreRaceSummaryMail.php`
+Nová Mailable třída.
+- Konstruktor: `SportEvent $event`, `Collection $entries` (with userRaceProfile + sportClassDefinition loaded)
+- Vrátí view `emails.event.preRaceSummary`
+
+### 2. `resources/views/emails/event/preRaceSummary.blade.php`
+Blade šablona e-mailu podle vzoru `sportEntryEnds.blade.php`.
+
+### 3. `app/Http/Controllers/Cron/Jobs/ReportEmailPreRaceSummary.php`
+Cron job třídy (vzor: `EntryEndsToPay`, `ReportEmailEventWeeklyEndsBySport`).
+Implementuje interface `CommonCronJobs` s metodou `run()`.
+
+```php
+// Pseudologika run():
+$targetDate = now()->addDays($daysBefore)->toDateString();
+
+$events = SportEvent::whereDate('date', $targetDate)
+    ->whereHas('userEntry')
+    ->with(['userEntry.userRaceProfile.user.userSetting', 
+            'userEntry.sportClassDefinition',
+            'sportEventNews' => fn($q) => $q->orderByDesc('date')->limit(5),
+            'sportEventLinks'])
+    ->get();
+
+foreach ($events as $event) {
+    // seskupit entries podle user_id
+    $entriesByUser = $event->userEntry->groupBy(fn($e) => $e->userRaceProfile->user_id);
+    
+    foreach ($entriesByUser as $userId => $entries) {
+        $user = $entries->first()->userRaceProfile->user;
+        $options = $user->getUserOptions('mail');
+        
+        if (!($options['pre_race_summary_enabled'] ?? false)) continue;
+        if ((int)($options['pre_race_summary_time_trigger'] ?? 17) !== now()->hour) continue;
+        
+        Mail::to($user->email)->send(new PreRaceSummaryMail($event, $entries));
+        Log::channel('site')->info('PreRaceSummary mail for user: ' . $user->email);
+    }
+}
+```
+
+### 4. Registrace v `CommonCron::runHourly()` – `app/Http/Controllers/Cron/CommonCron.php`
+Přidat nový blok stejného vzoru jako ostatní joby:
+```php
+/** @description Send Mail pre-race summary */
+try {
+    if ($this->runJob('mail_pre_race_summary')) {
+        Log::channel('site')->info('START MailPreRaceSummary run cron at '.$this->getActualHour());
+        new ReportEmailPreRaceSummary()->run();
+        Log::channel('site')->info('STOP  MailPreRaceSummary run cron at '.$this->getActualHour());
+    }
+} catch (Exception $e) {
+    Log::channel('site')->warning('ERROR MailPreRaceSummary: '.$e->getMessage());
+}
+```
+
+### 4b. Nový záznam v `config/site-config.php`
+Přidat do sekce `cron_hourly`:
+```php
+'mail_pre_race_summary' => [
+    'active' => true,
+    'hours' => ['*'],
+    'days_in_month' => ['*'],
+    'months' => ['*'],
+    'days_in_week' => ['*'],
+],
+```
+> `hours => ['*']` – job se spustí každou hodinu a interní logika rozhodne (podle `pre_race_summary_time_trigger` uživatele), komu mail odeslat.
+
+### 5. `app/Filament/Pages/UserMailNotification.php`
+Přidat do sekce „Emailové nastavení" novou podsekci **„Ostatní e-maily"**:
+
+| Klíč v options | Typ | Výchozí | Popis |
+|---|---|---|---|
+| `pre_race_summary_enabled` | bool | false | Zapnout souhrný mail |
+| `pre_race_summary_days_before` | int | 1 | Kolik dní předem |
+| `pre_race_summary_time_trigger` | int | 17 | V kolik hodin odeslat |
+
+---
+
+## Soubory ke změně / vytvoření
+
+| Akce | Soubor |
+|---|---|
+| Vytvořit | `app/Mail/PreRaceSummaryMail.php` |
+| Vytvořit | `resources/views/emails/event/preRaceSummary.blade.php` |
+| Vytvořit | `app/Http/Controllers/Cron/Jobs/ReportEmailPreRaceSummary.php` |
+| Upravit | `app/Http/Controllers/Cron/CommonCron.php` (přidat blok jobu) |
+| Upravit | `config/site-config.php` (přidat `mail_pre_race_summary` do `cron_hourly`) |
+| Upravit | `app/Filament/Pages/UserMailNotification.php` (nová sekce) |
+
+---
+
+## Vzorové soubory (inspirace)
+
+- `app/Http/Controllers/Cron/Jobs/EntryEndsToPay.php` – vzor pro cron job třídu
+- `app/Http/Controllers/Cron/CommonCron.php` – vzor pro registraci v runHourly()
+- `app/Mail/EventEntryEnds.php` – vzor pro Mailable
+- `resources/views/emails/event/sportEntryEnds.blade.php` – vzor pro šablonu
+- `app/Filament/Pages/UserMailNotification.php` – vzor pro settings UI
+
+---
+
+## Poznámky
+
+- `UserRaceProfile` může mít vlastní `email` – pokud není null, použít místo `user->email`
+- Multi-day akce: zobrazit rozsah dat `date – date_end` a počet dní
+- Startovní čas brát z `user_entries.requested_start`, fallback `real_start`, fallback null
+- Parametry kategorie (distance, controls, climbing) jsou na `sport_class_definitions` přes `user_entries.class_definition_id`

--- a/app/Console/Commands/SendPreRaceSummaryMailCommand.php
+++ b/app/Console/Commands/SendPreRaceSummaryMailCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Mail\PreRaceSummaryMail;
+use App\Models\SportEvent;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendPreRaceSummaryMailCommand extends Command
+{
+    protected $signature = 'mail:pre-race-summary
+                            {event_id : ID race}
+                            {email : Target e-mail address}';
+
+    protected $description = 'Send pre-race-summary summary, [eventID] [emailAddress]';
+
+    public function handle(): int
+    {
+        $eventId = (int) $this->argument('event_id');
+        $email = (string) $this->argument('email');
+
+        $event = SportEvent::with([
+            'userEntry.userRaceProfile.user.userSetting',
+            'userEntry.sportClassDefinition',
+            'sportClasses',
+            'sportEventNews' => fn ($q) => $q->orderByDesc('date')->limit(5),
+            'sportEventLinks',
+        ])->find($eventId);
+
+        if ($event === null) {
+            $this->error("Event ID {$eventId} was not found.");
+
+            return self::FAILURE;
+        }
+
+        $entries = $event->userEntry;
+
+        if ($entries->isEmpty()) {
+            $this->warn("Race '{$event->name}' are no entries.");
+        }
+
+        Mail::to($email)->send(new PreRaceSummaryMail($event, $entries));
+
+        $this->info("Email send {$email} for eventID: {$event->name}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Pages/UserMailNotification.php
+++ b/app/Filament/Pages/UserMailNotification.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
@@ -51,6 +52,10 @@ class UserMailNotification extends Page implements HasForms
 
     public array $week_report_by_sport = [];
 
+    public bool $pre_race_summary_enabled = false;
+    public int $pre_race_summary_days_before = 1;
+    public int $pre_race_summary_time_trigger = self::DEFAULT_TRIGGER_EVENT;
+
     public array $users_allow_sign_up_for_race = [];
 
     public array $event_filters = [];
@@ -73,6 +78,10 @@ class UserMailNotification extends Page implements HasForms
             $this->days_before_event_entry_ends = $mailNotification->options['days_before_event_entry_ends'] ?? 4;
 
             $this->week_report_by_sport = $mailNotification->options['week_report_by_sport'] ?? [];
+
+            $this->pre_race_summary_enabled = (bool) ($mailNotification->options['pre_race_summary_enabled'] ?? false);
+            $this->pre_race_summary_days_before = (int) ($mailNotification->options['pre_race_summary_days_before'] ?? 1);
+            $this->pre_race_summary_time_trigger = (int) ($mailNotification->options['pre_race_summary_time_trigger'] ?? self::DEFAULT_TRIGGER_EVENT);
         }
 
         $usersAllowSingUpForRace = UserSetting::where('user_id', '=', Auth::user()?->id)
@@ -191,6 +200,10 @@ class UserMailNotification extends Page implements HasForms
         $mailOptions['days_before_event_entry_ends'] = $this->days_before_event_entry_ends;
 
         $mailOptions['week_report_by_sport'] = $this->week_report_by_sport;
+
+        $mailOptions['pre_race_summary_enabled'] = $this->pre_race_summary_enabled;
+        $mailOptions['pre_race_summary_days_before'] = $this->pre_race_summary_days_before;
+        $mailOptions['pre_race_summary_time_trigger'] = $this->pre_race_summary_time_trigger;
         $this->storeMailOptions($mailOptions);
 
         /**
@@ -273,6 +286,28 @@ class UserMailNotification extends Page implements HasForms
                                     ->maxValue(14)
                                     ->minValue(1)
                                     ->default(4),
+                            ]),
+                        Section::make('Ostatní e-maily')
+                            ->description('Souhrný e-mail před závodem obsahuje informace o akci, startovní časy přihlášených závodníků a parametry jejich kategorií.')
+                            ->aside()
+                            ->columns(3)
+                            ->schema([
+                                Toggle::make('pre_race_summary_enabled')
+                                    ->label('Souhrn před závodem')
+                                    ->columnSpanFull()
+                                    ->default(false),
+                                TextInput::make('pre_race_summary_days_before')
+                                    ->label('Dnů před závodem')
+                                    ->numeric()
+                                    ->minValue(1)
+                                    ->maxValue(14)
+                                    ->default(1),
+                                TextInput::make('pre_race_summary_time_trigger')
+                                    ->label('Přibližná hodina odeslání')
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->maxValue(23)
+                                    ->default(self::DEFAULT_TRIGGER_EVENT),
                             ]),
                         Section::make('Souhrn závodů u kterých končí termín přihlášek následující týden')
                             ->description('V nastaveni definujete, které sporty budou v e-mailu souhrnně uvedeny. Souhrn obsahuje závody u kterých končí termín přihlášek následující týden.')

--- a/app/Filament/Pages/UserMailNotification.php
+++ b/app/Filament/Pages/UserMailNotification.php
@@ -287,6 +287,15 @@ class UserMailNotification extends Page implements HasForms
                                     ->minValue(1)
                                     ->default(4),
                             ]),
+                        Section::make('Souhrn závodů u kterých končí termín přihlášek následující týden')
+                            ->description('V nastaveni definujete, které sporty budou v e-mailu souhrnně uvedeny. Souhrn obsahuje závody u kterých končí termín přihlášek následující týden.')
+                            ->aside()
+                            ->columns(2)
+                            ->schema([
+                                CheckboxList::make('week_report_by_sport')
+                                    ->label('Sport')
+                                    ->options(SportList::all()->pluck('short_name', 'id')),
+                            ]),
                         Section::make('Ostatní e-maily')
                             ->description('Souhrný e-mail před závodem obsahuje informace o akci, startovní časy přihlášených závodníků a parametry jejich kategorií.')
                             ->aside()
@@ -308,15 +317,6 @@ class UserMailNotification extends Page implements HasForms
                                     ->minValue(0)
                                     ->maxValue(23)
                                     ->default(self::DEFAULT_TRIGGER_EVENT),
-                            ]),
-                        Section::make('Souhrn závodů u kterých končí termín přihlášek následující týden')
-                            ->description('V nastaveni definujete, které sporty budou v e-mailu souhrnně uvedeny. Souhrn obsahuje závody u kterých končí termín přihlášek následující týden.')
-                            ->aside()
-                            ->columns(2)
-                            ->schema([
-                                CheckboxList::make('week_report_by_sport')
-                                    ->label('Sport')
-                                    ->options(SportList::all()->pluck('short_name', 'id')),
                             ]),
                     ]),
 

--- a/app/Http/Controllers/Cron/CommonCron.php
+++ b/app/Http/Controllers/Cron/CommonCron.php
@@ -8,6 +8,7 @@ use Exception;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Cron\Jobs\EntryEndsToPay;
 use App\Http\Controllers\Cron\Jobs\ReportEmailEventWeeklyEndsBySport;
+use App\Http\Controllers\Cron\Jobs\ReportEmailPreRaceSummary;
 use App\Http\Controllers\Cron\Jobs\ReportEmailUserDebit;
 use App\Http\Controllers\Cron\Jobs\SyncEventStartLists;
 use App\Http\Controllers\Cron\Jobs\UpdateBankTransaction;
@@ -73,6 +74,17 @@ class CommonCron extends Controller
             }
         } catch (Exception $e) {
             Log::channel('site')->warning('ERROR ErrorMessage: '.$e->getMessage());
+        }
+
+        /** @description Send Mail pre-race summary */
+        try {
+            if ($this->runJob('mail_pre_race_summary')) {
+                Log::channel('site')->info('START MailPreRaceSummary run cron at '.$this->getActualHour());
+                new ReportEmailPreRaceSummary()->run();
+                Log::channel('site')->info('STOP  MailPreRaceSummary run cron at '.$this->getActualHour());
+            }
+        } catch (Exception $e) {
+            Log::channel('site')->warning('ERROR MailPreRaceSummary: '.$e->getMessage());
         }
 
         /** @description Sync event start lists from ORIS */

--- a/app/Http/Controllers/Cron/Jobs/ReportEmailPreRaceSummary.php
+++ b/app/Http/Controllers/Cron/Jobs/ReportEmailPreRaceSummary.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Cron\Jobs;
+
+use App\Mail\PreRaceSummaryMail;
+use App\Models\SportEvent;
+use App\Models\UserEntry;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class ReportEmailPreRaceSummary implements CommonCronJobs
+{
+    private const int MAX_DAYS_BEFORE = 14;
+
+    public function run(): void
+    {
+        for ($daysBefore = 1; $daysBefore <= self::MAX_DAYS_BEFORE; $daysBefore++) {
+            $targetDate = now()->addDays($daysBefore)->toDateString();
+
+            $events = SportEvent::whereDate('date', $targetDate)
+                ->whereHas('userEntry')
+                ->with([
+                    'userEntry.userRaceProfile.user.userSetting',
+                    'userEntry.sportClassDefinition',
+                    'sportClasses',
+                    'sportEventNews' => fn ($q) => $q->orderByDesc('date')->limit(5),
+                    'sportEventLinks',
+                ])
+                ->get();
+
+            foreach ($events as $event) {
+                $entriesByUser = [];
+
+                foreach ($event->userEntry as $entry) {
+                    $userId = $entry->userRaceProfile?->user_id;
+                    if ($userId === null) {
+                        continue;
+                    }
+                    $entriesByUser[$userId][] = $entry;
+                }
+
+                foreach ($entriesByUser as $entries) {
+                    /** @var UserEntry $firstEntry */
+                    $firstEntry = $entries[0];
+                    $user = $firstEntry->userRaceProfile?->user;
+
+                    if ($user === null) {
+                        continue;
+                    }
+
+                    $options = $user->getUserOptions();
+
+                    if (!($options['pre_race_summary_enabled'] ?? false)) {
+                        continue;
+                    }
+                    if ((int) ($options['pre_race_summary_days_before'] ?? 1) !== $daysBefore) {
+                        continue;
+                    }
+                    if ((int) ($options['pre_race_summary_time_trigger'] ?? 17) !== now()->hour) {
+                        continue;
+                    }
+
+                    $profile = $firstEntry->userRaceProfile;
+                    $emailTo = ($profile !== null && $profile->email !== null) ? $profile->email : $user->email;
+
+                    Mail::to($emailTo)->send(new PreRaceSummaryMail($event, collect($entries)));
+                    Log::channel('site')->info('PreRaceSummary mail for user: ' . $user->email);
+                }
+            }
+        }
+    }
+}

--- a/app/Mail/PreRaceSummaryMail.php
+++ b/app/Mail/PreRaceSummaryMail.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\SportEvent;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PreRaceSummaryMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private readonly SportEvent $event,
+        private readonly Collection $entries,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: config('app.name') . ' - Souhrn před závodem: ' . $this->event->name,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.event.preRaceSummary',
+            with: [
+                'event' => $this->event,
+                'entries' => $this->entries,
+            ]
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/SportEvent.php
+++ b/app/Models/SportEvent.php
@@ -155,6 +155,7 @@ class SportEvent extends Model
         return $this->hasMany(SportService::class, 'sport_event_id', 'id');
     }
 
+    /** @return HasMany<UserEntry, $this> */
     public function userEntry(): HasMany
     {
         return $this->HasMany(UserEntry::class, 'sport_event_id', 'id');

--- a/app/Services/OrisApiService.php
+++ b/app/Services/OrisApiService.php
@@ -128,7 +128,7 @@ final class OrisApiService
 
             /** @description Not update if the event exists */
             if ($newEvent) {
-                $eventModel->name = $orisData->Name ?? 'N/A';
+                $eventModel->name = $orisData->Name;
             }
             $eventModel->oris_id = $eventId;
             $eventModel->date = $orisData->Date;
@@ -141,7 +141,6 @@ final class OrisApiService
 
             $eventModel->entry_date_1 = strlen($orisData->EntryDate1) !== 0 ? $orisData->EntryDate1 : null;
 
-            //dd(!$eventModel->dont_update_excluded);
             if ($newEvent || ! $eventModel->dont_update_excluded) {
                 $eventModel->entry_date_2 = strlen($orisData->EntryDate2) !== 0 ? $orisData->EntryDate2 : null;
                 $eventModel->entry_date_3 = strlen($orisData->EntryDate3) !== 0 ? $orisData->EntryDate3 : null;

--- a/config/site-config.php
+++ b/config/site-config.php
@@ -154,6 +154,13 @@ return [
             'months' => ['*'],
             'days_in_week' => ['*'],
         ],
+        'mail_pre_race_summary' => [
+            'active' => true,
+            'hours' => ['*'],
+            'days_in_month' => ['*'],
+            'months' => ['*'],
+            'days_in_week' => ['*'],
+        ],
     ],
 
     'cron_url_key' => env('CRON_URL_KEY', 'cron_url_key'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "dalin",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -2637,9 +2637,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.27.0",

--- a/resources/views/emails/event/preRaceSummary.blade.php
+++ b/resources/views/emails/event/preRaceSummary.blade.php
@@ -7,9 +7,11 @@
 
 ## Souhrn před závodem: {{ $event->name }}
 
----
+{{ $event->alt_name }}
 
+@component('mail::divider')
 ### Informace o akci
+@endcomponent
 
 @component('mail::table')
 | | |
@@ -26,8 +28,8 @@
 ### Závodní profily
 
 @component('mail::table')
-| Reg. číslo | Jméno | Kategorie | Start | +min | Délka | Kontroly | Převýšení |
-|:---|:---|:---|:---|:---|:---|:---|:---|
+| Reg. číslo | Jméno | Kategorie | +min | Délka | Kontroly | Převýšení |
+|:---|:---|:---|:---|:---|:---|:---|
 @foreach($entries as $entry)
 @php
     $profile = $entry->userRaceProfile;
@@ -45,7 +47,7 @@
     }
     $sportClass = $event->sportClasses->firstWhere('class_definition_id', $entry->class_definition_id);
 @endphp
-| {{ $profile?->reg_number ?? '–' }} | {{ $profile?->first_name }} {{ $profile?->last_name }} | {{ $entry->class_name ?? '–' }} | {{ $startDisplay ?? '–' }} | {{ $relativeMinutes !== null ? ($relativeMinutes >= 0 ? '+'.$relativeMinutes : $relativeMinutes) : '–' }} | {{ $sportClass?->distance ? $sportClass->distance.' km' : '–' }} | {{ $sportClass?->controls ?? '–' }} | {{ $sportClass?->climbing ? $sportClass->climbing.' m' : '–' }} |
+| {{ $profile?->reg_number ?? '–' }} | {{ $profile?->first_name }} {{ $profile?->last_name }} | {{ $entry->class_name ?? '–' }} | {{ $relativeMinutes !== null ? ($relativeMinutes >= 0 ? '+'.$relativeMinutes : $relativeMinutes) : '–' }} | {{ $sportClass?->distance ? $sportClass->distance.' km' : '–' }} | {{ $sportClass?->controls ?? '–' }} | {{ $sportClass?->climbing ? $sportClass->climbing.' m' : '–' }} |
 @endforeach
 @endcomponent
 
@@ -68,7 +70,7 @@
 | Název | Odkaz |
 |:---|:---|
 @foreach($event->sportEventLinks as $link)
-| {{ $link->name_cz ?? $link->name_en ?? '–' }} | @if($link->source_url)[{{ $link->name_cz ?? $link->source_url }}]({{ $link->source_url }})@else–@endif |
+| {{ $link->name_cz ?? $link->description_cz ?? '–' }} | @if($link->source_url)[{{ $link->name_cz ?? $link->source_url }}]({{ $link->source_url }})@else–@endif |
 @endforeach
 @endcomponent
 @endif

--- a/resources/views/emails/event/preRaceSummary.blade.php
+++ b/resources/views/emails/event/preRaceSummary.blade.php
@@ -1,0 +1,93 @@
+@php
+    use App\Services\OrisApiService;
+    use Illuminate\Support\Carbon;
+@endphp
+
+<x-mail::message>
+
+## Souhrn před závodem: {{ $event->name }}
+
+---
+
+### Informace o akci
+
+@component('mail::table')
+| | |
+|:---|:---|
+| **Datum** | {{ $event->date->format('d.m.Y') }}@if($event->date_end && $event->date_end->ne($event->date)) – {{ $event->date_end->format('d.m.Y') }} ({{ $event->date->diffInDays($event->date_end) + 1 }} {{ $event->date->diffInDays($event->date_end) + 1 === 1 ? 'den' : 'dny' }})@endif |
+| **Start první etapy** | {{ $event->start_time ?? '–' }} |
+@if($event->oris_id)
+| **ORIS** | [Závod {{ $event->oris_id }}]({{ OrisApiService::ORIS_URL }}/Zavod?id={{ $event->oris_id }}) |
+@endif
+@endcomponent
+
+---
+
+### Závodní profily
+
+@component('mail::table')
+| Reg. číslo | Jméno | Kategorie | Start | +min | Délka | Kontroly | Převýšení |
+|:---|:---|:---|:---|:---|:---|:---|:---|
+@foreach($entries as $entry)
+@php
+    $profile = $entry->userRaceProfile;
+    $startRaw = $entry->requested_start ?? ($entry->real_start?->format('H:i:s'));
+    $startDisplay = $startRaw ? \Illuminate\Support\Str::substr($startRaw, 0, 5) : null;
+    $relativeMinutes = null;
+    if ($startRaw !== null && $event->start_time !== null) {
+        try {
+            $fmt = strlen(trim($startRaw)) === 5 ? 'H:i' : 'H:i:s';
+            $fmtEvent = strlen(trim($event->start_time)) === 5 ? 'H:i' : 'H:i:s';
+            $entryCarbon = Carbon::createFromFormat($fmt, trim($startRaw));
+            $eventCarbon = Carbon::createFromFormat($fmtEvent, trim($event->start_time));
+            $relativeMinutes = (int) $eventCarbon->diffInMinutes($entryCarbon, false);
+        } catch (\Exception) {}
+    }
+    $sportClass = $event->sportClasses->firstWhere('class_definition_id', $entry->class_definition_id);
+@endphp
+| {{ $profile?->reg_number ?? '–' }} | {{ $profile?->first_name }} {{ $profile?->last_name }} | {{ $entry->class_name ?? '–' }} | {{ $startDisplay ?? '–' }} | {{ $relativeMinutes !== null ? ($relativeMinutes >= 0 ? '+'.$relativeMinutes : $relativeMinutes) : '–' }} | {{ $sportClass?->distance ? $sportClass->distance.' km' : '–' }} | {{ $sportClass?->controls ?? '–' }} | {{ $sportClass?->climbing ? $sportClass->climbing.' m' : '–' }} |
+@endforeach
+@endcomponent
+
+@if($event->event_info)
+
+---
+
+### Popis akce
+
+{{ $event->event_info }}
+@endif
+
+@if($event->sportEventLinks->isNotEmpty())
+
+---
+
+### Linky
+
+@component('mail::table')
+| Název | Odkaz |
+|:---|:---|
+@foreach($event->sportEventLinks as $link)
+| {{ $link->name_cz ?? $link->name_en ?? '–' }} | @if($link->source_url)[{{ $link->name_cz ?? $link->source_url }}]({{ $link->source_url }})@else–@endif |
+@endforeach
+@endcomponent
+@endif
+
+@if($event->sportEventNews->isNotEmpty())
+
+---
+
+### Novinky
+
+@foreach($event->sportEventNews as $news)
+**{{ $news->date->format('d.m.Y') }}**
+
+{{ $news->text }}
+
+@if(!$loop->last)
+---
+@endif
+@endforeach
+@endif
+
+</x-mail::message>

--- a/resources/views/scribe/index.blade.php
+++ b/resources/views/scribe/index.blade.php
@@ -128,7 +128,7 @@
     </ul>
 
     <ul class="toc-footer" id="last-updated">
-        <li>Last updated: April 17, 2026</li>
+        <li>Last updated: April 23, 2026</li>
     </ul>
 </div>
 
@@ -381,8 +381,8 @@ $response = $client-&gt;get(
             'per_page' =&gt; '20',
         ],
         'json' =&gt; [
-            'from' =&gt; '2026-04-17',
-            'to' =&gt; '2026-04-17',
+            'from' =&gt; '2026-04-23',
+            'to' =&gt; '2026-04-23',
             'per_page' =&gt; 1,
         ],
     ]
@@ -397,8 +397,8 @@ print_r(json_decode((string) $body));</code></pre></div>
     --header "Content-Type: application/json" \
     --header "Accept: application/json" \
     --data "{
-    \"from\": \"2026-04-17\",
-    \"to\": \"2026-04-17\",
+    \"from\": \"2026-04-23\",
+    \"to\": \"2026-04-23\",
     \"per_page\": 1
 }"
 </code></pre></div>
@@ -424,8 +424,8 @@ const headers = {
 };
 
 let body = {
-    "from": "2026-04-17",
-    "to": "2026-04-17",
+    "from": "2026-04-23",
+    "to": "2026-04-23",
     "per_page": 1
 };
 
@@ -613,10 +613,10 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
                 <input type="text" style="display: none"
                               name="from"                data-endpoint="GETapi-v1-user-entry"
-               value="2026-04-17"
+               value="2026-04-23"
                data-component="body">
     <br>
-<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-17</code></p>
+<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-23</code></p>
         </div>
                 <div style=" padding-left: 28px;  clear: unset;">
             <b style="line-height: 2;"><code>to</code></b>&nbsp;&nbsp;
@@ -625,10 +625,10 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
                 <input type="text" style="display: none"
                               name="to"                data-endpoint="GETapi-v1-user-entry"
-               value="2026-04-17"
+               value="2026-04-23"
                data-component="body">
     <br>
-<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-17</code></p>
+<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-23</code></p>
         </div>
                 <div style=" padding-left: 28px;  clear: unset;">
             <b style="line-height: 2;"><code>per_page</code></b>&nbsp;&nbsp;
@@ -1501,7 +1501,7 @@ You can check the Dev Tools console for debugging information.</code></pre>
 
 <div class="php-example">
     <pre><code class="language-php">$client = new \GuzzleHttp\Client();
-$url = 'http://localhost/api/v1/page/1';
+$url = 'http://localhost/api/v1/page/16';
 $response = $client-&gt;get(
     $url,
     [
@@ -1517,14 +1517,14 @@ print_r(json_decode((string) $body));</code></pre></div>
 
 <div class="bash-example">
     <pre><code class="language-bash">curl --request GET \
-    --get "http://localhost/api/v1/page/1" \
+    --get "http://localhost/api/v1/page/16" \
     --header "Content-Type: application/json" \
     --header "Accept: application/json"</code></pre></div>
 
 
 <div class="javascript-example">
     <pre><code class="language-javascript">const url = new URL(
-    "http://localhost/api/v1/page/1"
+    "http://localhost/api/v1/page/16"
 );
 
 const headers = {
@@ -1710,10 +1710,10 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
                 <input type="number" style="display: none"
                step="any"               name="page_id"                data-endpoint="GETapi-v1-page--page_id-"
-               value="1"
+               value="16"
                data-component="url">
     <br>
-<p>The ID of the page. Example: <code>1</code></p>
+<p>The ID of the page. Example: <code>16</code></p>
             </div>
                     </form>
 
@@ -1751,8 +1751,8 @@ $response = $client-&gt;get(
             'per_page' =&gt; '20',
         ],
         'json' =&gt; [
-            'from' =&gt; '2026-04-17',
-            'to' =&gt; '2026-04-17',
+            'from' =&gt; '2026-04-23',
+            'to' =&gt; '2026-04-23',
             'class_definition_id' =&gt; 16,
             'per_page' =&gt; 22,
         ],
@@ -1768,8 +1768,8 @@ print_r(json_decode((string) $body));</code></pre></div>
     --header "Content-Type: application/json" \
     --header "Accept: application/json" \
     --data "{
-    \"from\": \"2026-04-17\",
-    \"to\": \"2026-04-17\",
+    \"from\": \"2026-04-23\",
+    \"to\": \"2026-04-23\",
     \"class_definition_id\": 16,
     \"per_page\": 22
 }"
@@ -1798,8 +1798,8 @@ const headers = {
 };
 
 let body = {
-    "from": "2026-04-17",
-    "to": "2026-04-17",
+    "from": "2026-04-23",
+    "to": "2026-04-23",
     "class_definition_id": 16,
     "per_page": 22
 };
@@ -2022,10 +2022,10 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
                 <input type="text" style="display: none"
                               name="from"                data-endpoint="GETapi-v1-sport-event"
-               value="2026-04-17"
+               value="2026-04-23"
                data-component="body">
     <br>
-<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-17</code></p>
+<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-23</code></p>
         </div>
                 <div style=" padding-left: 28px;  clear: unset;">
             <b style="line-height: 2;"><code>to</code></b>&nbsp;&nbsp;
@@ -2034,10 +2034,10 @@ You can check the Dev Tools console for debugging information.</code></pre>
  &nbsp;
                 <input type="text" style="display: none"
                               name="to"                data-endpoint="GETapi-v1-sport-event"
-               value="2026-04-17"
+               value="2026-04-23"
                data-component="body">
     <br>
-<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-17</code></p>
+<p>Must be a valid date in the format <code>Y-m-d</code>. Example: <code>2026-04-23</code></p>
         </div>
                 <div style=" padding-left: 28px;  clear: unset;">
             <b style="line-height: 2;"><code>event_type</code></b>&nbsp;&nbsp;


### PR DESCRIPTION
Implemented logic to send scheduled pre-race summary emails to users, including event details, user-specific profiles, and optional event-related content. Added support in user settings for enabling/disabling emails, days before sending, and time of day trigger. Updated cron system and UI. Added new models, views, and mailable classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pre-race summary email notifications allowing users to receive race event summaries before competitions
  * New mail notification settings provide customizable timing controls for pre-race emails, including days in advance and preferred delivery hour
  * Pre-race summary emails include event details, race profiles, and relevant race information

* **Documentation**
  * Updated API documentation with current examples and dates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->