### PR TITLE
feat(ical): add personal iCal feeds with token-based authentication

### DIFF
--- a/app/Filament/Pages/UserMailNotification.php
+++ b/app/Filament/Pages/UserMailNotification.php
@@ -26,6 +26,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
+use App\Services\CalendarTokenService;
 
 class UserMailNotification extends Page implements HasForms
 {
@@ -58,6 +59,9 @@ class UserMailNotification extends Page implements HasForms
     public ?string $api_key = null;
     public bool $has_api_key = false;
     public bool $show_api_key = false;
+
+    public ?string $calendar_token = null;
+    public bool $has_calendar_token = false;
 
     public function mount(): void
     {
@@ -102,6 +106,11 @@ class UserMailNotification extends Page implements HasForms
         if ($this->has_api_key && $user?->api_key_hash !== null) {
             $this->api_key = $user->api_key_hash;
             $this->show_api_key = true;
+        }
+
+        $this->has_calendar_token = $user->calendar_token !== null;
+        if ($this->has_calendar_token) {
+            $this->calendar_token = $user->calendar_token;
         }
     }
     public function generateApiKey(): void
@@ -170,6 +179,70 @@ class UserMailNotification extends Page implements HasForms
             ->title('Zkopírováno')
             ->success()
             ->body('API klíč byl zkopírován do schránky.')
+            ->send();
+    }
+
+    public function generateCalendarToken(): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $service = new CalendarTokenService();
+        $this->calendar_token = $service->generate($user);
+        $this->has_calendar_token = true;
+
+        Notification::make()
+            ->title('Kalendářový token vygenerován')
+            ->success()
+            ->body('Nový token byl úspěšně vygenerován.')
+            ->send();
+    }
+
+    public function regenerateCalendarToken(): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $service = new CalendarTokenService();
+        $this->calendar_token = $service->regenerate($user);
+        $this->has_calendar_token = true;
+
+        Notification::make()
+            ->title('Kalendářový token přegenerován')
+            ->success()
+            ->body('Starý token byl zneplatněn. Nový token byl úspěšně vygenerován.')
+            ->send();
+    }
+
+    public function revokeCalendarToken(): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $service = new CalendarTokenService();
+        $service->revoke($user);
+        $this->calendar_token = null;
+        $this->has_calendar_token = false;
+
+        Notification::make()
+            ->title('Kalendářový token zrušen')
+            ->success()
+            ->body('Token byl úspěšně zrušen.')
+            ->send();
+    }
+
+    public function copyCalendarToken(): void
+    {
+        Notification::make()
+            ->title('Zkopírováno')
+            ->success()
+            ->body('Kalendářový token byl zkopírován do schránky.')
+            ->send();
+    }
+
+    public function copyCalendarUrl(): void
+    {
+        Notification::make()
+            ->title('Zkopírováno')
+            ->success()
+            ->body('Adresa kalendářového kanálu byla zkopírována do schránky.')
             ->send();
     }
 
@@ -346,6 +419,16 @@ class UserMailNotification extends Page implements HasForms
                                         'showApiKey' => $this->show_api_key,
                                         'apiKey' => $this->api_key,
                                     ])
+                            ]),
+                    ]),
+
+                Tab::make('Kalendář')
+                    ->schema([
+                        Section::make('Správa kalendářového tokenu')
+                            ->description('Kalendářový token slouží pro přístup k vašim osobním iCalendar kanálům.')
+                            ->aside()
+                            ->schema([
+                                View::make('filament.pages.components.calendar-token-manager')
                             ]),
                     ]),
             ])

--- a/app/Filament/Pages/UserMailNotification.php
+++ b/app/Filament/Pages/UserMailNotification.php
@@ -246,6 +246,15 @@ class UserMailNotification extends Page implements HasForms
             ->send();
     }
 
+    public function copyCalendarUrlFailed(): void
+    {
+        Notification::make()
+            ->title('Chyba')
+            ->danger()
+            ->body('Adresu se nepodařilo zkopírovat do schránky.')
+            ->send();
+    }
+
     public function submit(): void
     {
         /** @var \Filament\Schemas\Schema $form */

--- a/app/Filament/Pages/UserMailNotification.php
+++ b/app/Filament/Pages/UserMailNotification.php
@@ -424,8 +424,8 @@ class UserMailNotification extends Page implements HasForms
 
                 Tab::make('Kalendář')
                     ->schema([
-                        Section::make('Správa kalendářového tokenu')
-                            ->description('Kalendářový token slouží pro přístup k vašim osobním iCalendar kanálům.')
+                        Section::make('Kalendářové feedy')
+                            ->description('Veřejné feedy jsou dostupné bez přihlášení. Osobní feedy vyžadují vygenerování tokenu a zobrazují pouze vaše závody a tréninky. Feedy lze přidat do Google Calendar, Apple Calendar a dalších aplikací podporujících iCal.')
                             ->aside()
                             ->schema([
                                 View::make('filament.pages.components.calendar-token-manager')

--- a/app/Http/Controllers/Ical/CalendarController.php
+++ b/app/Http/Controllers/Ical/CalendarController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Ical;
 
 use App\Http\Controllers\Controller;
+use App\Services\CalendarTokenService;
 use App\Services\IcalService;
 use Illuminate\Http\Response;
 use Knuckles\Scribe\Attributes\Group;
@@ -14,11 +15,10 @@ use Knuckles\Scribe\Attributes\Subgroup;
 #[Subgroup("ICAL", "Server ical calendar feed")]
 class CalendarController extends Controller
 {
-    private IcalService $icalService;
-
-    public function __construct(?IcalService $icalService)
-    {
-        $this->icalService = $icalService ?? new IcalService();
+    public function __construct(
+        private readonly IcalService $icalService,
+        private readonly CalendarTokenService $calendarTokenService,
+    ) {
     }
 
     public function raceCalendar(): Response
@@ -33,5 +33,33 @@ class CalendarController extends Controller
         return response($this->icalService->getTrainingCalendar()->get())
             ->header('Content-Type', 'text/calendar; charset=utf-8')
             ->header('Content-Disposition', 'attachment; filename="abm-treninky.ics"');
+    }
+
+    public function personalRaceCalendar(string $token): Response
+    {
+        $user = $this->calendarTokenService->validate($token);
+
+        if ($user === null) {
+            abort(404);
+        }
+
+        return response($this->icalService->getPersonalRaceCalendar($user)->get())
+            ->header('Content-Type', 'text/calendar; charset=utf-8')
+            ->header('Content-Disposition', 'attachment; filename="abm-moje-zavody.ics"')
+            ->header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    }
+
+    public function personalTrainingCalendar(string $token): Response
+    {
+        $user = $this->calendarTokenService->validate($token);
+
+        if ($user === null) {
+            abort(404);
+        }
+
+        return response($this->icalService->getPersonalTrainingCalendar($user)->get())
+            ->header('Content-Type', 'text/calendar; charset=utf-8')
+            ->header('Content-Disposition', 'attachment; filename="abm-moje-treninky.ics"')
+            ->header('Cache-Control', 'no-cache, no-store, must-revalidate');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,6 +40,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property bool $active
  * @property string|null $remember_token
  * @property string|null $api_key_hash
+ * @property string|null $calendar_token
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read string $user_identification
@@ -79,6 +80,7 @@ class User extends Authenticatable implements FilamentUser
         'password',
         'payer_variable_symbol',
         'active',
+        'calendar_token',
     ];
 
     /** @var list<string> */
@@ -86,6 +88,7 @@ class User extends Authenticatable implements FilamentUser
         'password',
         'remember_token',
         'api_key_hash',
+        'calendar_token',
     ];
 
     /** @var array<string, string> */

--- a/app/Services/CalendarTokenService.php
+++ b/app/Services/CalendarTokenService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+
+final class CalendarTokenService
+{
+    public function generate(User $user): string
+    {
+        $plain = bin2hex(random_bytes(32));
+        $user->calendar_token = $plain;
+        $user->save();
+
+        return $plain;
+    }
+
+    public function validate(string $token): ?User
+    {
+        return User::where('calendar_token', $token)->first();
+    }
+
+    public function revoke(User $user): void
+    {
+        $user->calendar_token = null;
+        $user->save();
+    }
+
+    public function regenerate(User $user): string
+    {
+        return $this->generate($user);
+    }
+
+    public function hasToken(User $user): bool
+    {
+        return $user->calendar_token !== null;
+    }
+}

--- a/app/Services/IcalService.php
+++ b/app/Services/IcalService.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\EntryStatus;
 use App\Enums\SportEventType;
 use App\Models\SportEvent;
+use App\Models\User;
+use App\Models\UserEntry;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\IcalendarGenerator\Components\Calendar;
@@ -32,15 +35,33 @@ final class IcalService
             ->event($this->getEvents(SportEventType::Training));
     }
 
+    public function getPersonalRaceCalendar(User $user): Calendar
+    {
+        return Calendar::create()
+            ->name(config('site-config.club.abbr').' - Moje závody')
+            ->description('Kalendař závodů na tento a následujici rok — pouze akce kde jsi přihlášen/a.')
+            ->event($this->getEvents(SportEventType::Race, $user));
+    }
+
+    public function getPersonalTrainingCalendar(User $user): Calendar
+    {
+        return Calendar::create()
+            ->name(config('site-config.club.abbr').' - Moje tréninky')
+            ->description('Kalendař tréninků na tento a následujici rok — pouze akce kde jsi přihlášen/a.')
+            ->event($this->getEvents(SportEventType::Training, $user));
+    }
+
     /**
      * @return Event[]
      */
-    public function getEvents(SportEventType $type): array
+    public function getEvents(SportEventType $type, ?User $user = null): array
     {
         $icalEvents = [];
 
         /** @var Collection<int, SportEvent> $sportEvents */
-        $sportEvents = $this->getEventByType($type);
+        $sportEvents = $user !== null
+            ? $this->getEventsByUser($user, $type)
+            : $this->getEventByType($type);
 
         foreach ($sportEvents as $sportEvent) {
 
@@ -111,6 +132,26 @@ final class IcalService
     private function getEventByType(SportEventType $type): Collection
     {
         return SportEvent::query()
+            ->where('event_type', '=', $type)
+            ->where('date', '>', Carbon::now()->startOfYear())
+            ->where('date', '<', Carbon::now()->endOfYear()->addYear())
+            ->where('cancelled', false)
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, SportEvent>
+     */
+    private function getEventsByUser(User $user, SportEventType $type): Collection
+    {
+        $profileIds = $user->userRaceProfiles()->pluck('id');
+        $sportEventIds = UserEntry::query()
+            ->whereIn('user_race_profile_id', $profileIds)
+            ->where('entry_status', '!=', EntryStatus::Cancel)
+            ->pluck('sport_event_id');
+
+        return SportEvent::query()
+            ->whereIn('id', $sportEventIds)
             ->where('event_type', '=', $type)
             ->where('date', '>', Carbon::now()->startOfYear())
             ->where('date', '<', Carbon::now()->endOfYear()->addYear())

--- a/database/migrations/2026_04_21_145939_add_calendar_token_to_users_table.php
+++ b/database/migrations/2026_04_21_145939_add_calendar_token_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->char('calendar_token', 64)->nullable()->unique()->after('api_key_hash');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('calendar_token');
+        });
+    }
+};

--- a/resources/views/filament/pages/components/calendar-token-manager.blade.php
+++ b/resources/views/filament/pages/components/calendar-token-manager.blade.php
@@ -1,0 +1,136 @@
+<div class="space-y-4">
+    @if($this->has_calendar_token)
+        <div class="space-y-3">
+            <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
+                <div class="flex items-center gap-2 mb-3">
+                    <svg class="w-5 h-5 text-success-600 dark:text-success-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"></path>
+                    </svg>
+                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Soukromé kalendáře
+                    </span>
+                </div>
+                <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    Máte aktivní token pro přístup k iCalendar kanálům. Používejte níže uvedené adresy v aplikacích, které podporují iCalendar formát.
+                </p>
+
+                <div class="space-y-3 mb-4">
+                    <div>
+                        <label class="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                            Kanál závodů (races)
+                        </label>
+                        <div class="flex gap-2">
+                            <div class="flex-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-2 font-mono text-xs break-all">
+                                {{ url('/api/feed/kalendar/zavody/me') }}/{{ $this->calendar_token }}
+                            </div>
+                            <button
+                                type="button"
+                                onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/me') }}/{{ $this->calendar_token }}'); $wire.call('copyCalendarUrl')"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                            Kanál tréninků (trainings)
+                        </label>
+                        <div class="flex gap-2">
+                            <div class="flex-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-2 font-mono text-xs break-all">
+                                {{ url('/api/feed/kalendar/treninky/me') }}/{{ $this->calendar_token }}
+                            </div>
+                            <button
+                                type="button"
+                                onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/me') }}/{{ $this->calendar_token }}'); $wire.call('copyCalendarUrl')"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex gap-3">
+                    <button
+                        type="button"
+                        wire:click="regenerateCalendarToken"
+                        wire:confirm="Opravdu chcete přegenerovat token? Starý token přestane fungovat a všechny odkazy na kanály budou neplatné."
+                        class="flex-1 px-4 py-2 bg-warning-600 hover:bg-warning-700 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+                    >
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+                        </svg>
+                        Přegenerovat token
+                    </button>
+
+                    <button
+                        type="button"
+                        wire:click="revokeCalendarToken"
+                        wire:confirm="Opravdu chcete zrušit token? Všechny odkazy na kanály budou neplatné."
+                        class="flex-1 px-4 py-2 bg-danger-600 hover:bg-danger-700 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+                    >
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                        </svg>
+                        Zrušit token
+                    </button>
+                </div>
+            </div>
+        </div>
+    @else
+        <div class="space-y-3">
+            <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
+                <div class="flex items-center gap-2 mb-2">
+                    <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
+                    </svg>
+                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Žádný kalendářový token
+                    </span>
+                </div>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Nemáte vygenerovaný token. Vygenerujte si jej pro přístup k vašim osobním iCalendar kanálům.
+                </p>
+            </div>
+
+            <button
+                type="button"
+                wire:click="generateCalendarToken"
+                class="w-full px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+            >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                </svg>
+                Vygenerovat token
+            </button>
+        </div>
+    @endif
+
+    <div class="bg-info-50 dark:bg-info-900/20 border border-info-200 dark:border-info-800 rounded-lg p-4">
+        <div class="flex gap-3">
+            <div class="flex-shrink-0">
+                <svg class="w-5 h-5 text-info-600 dark:text-info-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+            </div>
+            <div class="flex-1">
+                <h4 class="text-sm font-medium text-info-800 dark:text-info-200 mb-1">
+                    Důležité informace
+                </h4>
+                <ul class="text-sm text-info-700 dark:text-info-300 space-y-1 list-disc list-inside">
+                    <li>Token slouží pro přístup k vašim osobním iCalendar kanálům</li>
+                    <li>Adresy kanálů jsou vždy viditelné, dokud máte aktivní token</li>
+                    <li>Token můžete kdykoliv přegenerovat nebo zrušit</li>
+                    <li>Po přegenerování přestane starý token fungovat</li>
+                    <li>Používejte odkaz na kanál v aplikacích podporujících iCalendar (např. Google Calendar, Apple Calendar, Outlook)</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/filament/pages/components/calendar-token-manager.blade.php
+++ b/resources/views/filament/pages/components/calendar-token-manager.blade.php
@@ -1,3 +1,10 @@
+@php
+    $publicRacesUrl = url('/api/feed/kalendar/zavody/all/');
+    $publicTrainingsUrl = url('/api/feed/kalendar/treninky/all/');
+    $publicRacesWebcal = str_replace(['https://', 'http://'], 'webcal://', $publicRacesUrl);
+    $publicTrainingsWebcal = str_replace(['https://', 'http://'], 'webcal://', $publicTrainingsUrl);
+@endphp
+
 <div class="space-y-4">
     <!-- Public calendar feeds -->
     <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
@@ -31,6 +38,28 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                         </svg>
                     </button>
+                    <a
+                        href="{{ $publicRacesWebcal }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Přidat do kalendáře"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                        </svg>
+                    </a>
+                    <a
+                        href="https://calendar.google.com/calendar/render?cid={{ urlencode($publicRacesWebcal) }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Přidat do Google Kalendáře"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
+                        </svg>
+                    </a>
                 </div>
             </div>
 
@@ -51,12 +80,40 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                         </svg>
                     </button>
+                    <a
+                        href="{{ $publicTrainingsWebcal }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Přidat do kalendáře"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                        </svg>
+                    </a>
+                    <a
+                        href="https://calendar.google.com/calendar/render?cid={{ urlencode($publicTrainingsWebcal) }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Přidat do Google Kalendáře"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
+                        </svg>
+                    </a>
                 </div>
             </div>
         </div>
     </div>
 
     @if($this->has_calendar_token)
+        @php
+            $privateRacesUrl = url('/api/feed/kalendar/zavody/me') . '/' . $this->calendar_token;
+            $privateTrainingsUrl = url('/api/feed/kalendar/treninky/me') . '/' . $this->calendar_token;
+            $privateRacesWebcal = str_replace(['https://', 'http://'], 'webcal://', $privateRacesUrl);
+            $privateTrainingsWebcal = str_replace(['https://', 'http://'], 'webcal://', $privateTrainingsUrl);
+        @endphp
         <div class="space-y-3">
             <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
                 <div class="flex items-center gap-2 mb-3">
@@ -89,6 +146,28 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                 </svg>
                             </button>
+                            <a
+                                href="{{ $privateRacesWebcal }}"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Přidat do kalendáře"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
+                            </a>
+                            <a
+                                href="https://calendar.google.com/calendar/render?cid={{ urlencode($privateRacesWebcal) }}"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Přidat do Google Kalendáře"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
+                                </svg>
+                            </a>
                         </div>
                     </div>
 
@@ -109,6 +188,28 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                 </svg>
                             </button>
+                            <a
+                                href="{{ $privateTrainingsWebcal }}"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Přidat do kalendáře"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
+                            </a>
+                            <a
+                                href="https://calendar.google.com/calendar/render?cid={{ urlencode($privateTrainingsWebcal) }}"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Přidat do Google Kalendáře"
+                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                            >
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
+                                </svg>
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/resources/views/filament/pages/components/calendar-token-manager.blade.php
+++ b/resources/views/filament/pages/components/calendar-token-manager.blade.php
@@ -31,11 +31,16 @@
                     </div>
                     <button
                         type="button"
-                        onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/all/') }}'); $wire.call('copyCalendarUrl')"
-                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                        x-data="{ copied: false }"
+                        @click="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/all/') }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) }).catch(() => $wire.call('copyCalendarUrlFailed'))"
+                        :class="copied ? 'bg-success-500 dark:bg-success-600 text-white' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white'"
+                        class="flex-shrink-0 px-3 py-2 rounded-lg transition-colors"
                     >
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                        </svg>
+                        <svg x-show="copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                         </svg>
                     </button>
                     <a
@@ -56,9 +61,7 @@
                         title="Přidat do Google Kalendáře"
                         class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
                     >
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
-                        </svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-calendar-plus-icon lucide-calendar-plus w-4 h-4"><path d="M16 19h6"/><path d="M16 2v4"/><path d="M19 16v6"/><path d="M21 12.598V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8.5"/><path d="M3 10h18"/><path d="M8 2v4"/></svg>
                     </a>
                 </div>
             </div>
@@ -73,11 +76,16 @@
                     </div>
                     <button
                         type="button"
-                        onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/all/') }}'); $wire.call('copyCalendarUrl')"
-                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                        x-data="{ copied: false }"
+                        @click="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/all/') }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) }).catch(() => $wire.call('copyCalendarUrlFailed'))"
+                        :class="copied ? 'bg-success-500 dark:bg-success-600 text-white' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white'"
+                        class="flex-shrink-0 px-3 py-2 rounded-lg transition-colors"
                     >
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                        </svg>
+                        <svg x-show="copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                         </svg>
                     </button>
                     <a
@@ -98,9 +106,7 @@
                         title="Přidat do Google Kalendáře"
                         class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
                     >
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
-                        </svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-calendar-plus-icon lucide-calendar-plus w-4 h-4"><path d="M16 19h6"/><path d="M16 2v4"/><path d="M19 16v6"/><path d="M21 12.598V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8.5"/><path d="M3 10h18"/><path d="M8 2v4"/></svg>
                     </a>
                 </div>
             </div>
@@ -139,11 +145,16 @@
                             </div>
                             <button
                                 type="button"
-                                onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/me') }}/{{ $this->calendar_token }}'); $wire.call('copyCalendarUrl')"
-                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                                x-data="{ copied: false }"
+                                @click="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/me') }}/{{ $this->calendar_token }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) }).catch(() => $wire.call('copyCalendarUrlFailed'))"
+                                :class="copied ? 'bg-success-500 dark:bg-success-600 text-white' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white'"
+                                class="flex-shrink-0 px-3 py-2 rounded-lg transition-colors"
                             >
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                </svg>
+                                <svg x-show="copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                                 </svg>
                             </button>
                             <a
@@ -164,9 +175,7 @@
                                 title="Přidat do Google Kalendáře"
                                 class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
                             >
-                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
-                                </svg>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-calendar-plus-icon lucide-calendar-plus w-4 h-4"><path d="M16 19h6"/><path d="M16 2v4"/><path d="M19 16v6"/><path d="M21 12.598V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8.5"/><path d="M3 10h18"/><path d="M8 2v4"/></svg>
                             </a>
                         </div>
                     </div>
@@ -181,11 +190,16 @@
                             </div>
                             <button
                                 type="button"
-                                onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/me') }}/{{ $this->calendar_token }}'); $wire.call('copyCalendarUrl')"
-                                class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                                x-data="{ copied: false }"
+                                @click="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/me') }}/{{ $this->calendar_token }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) }).catch(() => $wire.call('copyCalendarUrlFailed'))"
+                                :class="copied ? 'bg-success-500 dark:bg-success-600 text-white' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white'"
+                                class="flex-shrink-0 px-3 py-2 rounded-lg transition-colors"
                             >
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                </svg>
+                                <svg x-show="copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                                 </svg>
                             </button>
                             <a
@@ -206,9 +220,7 @@
                                 title="Přidat do Google Kalendáře"
                                 class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
                             >
-                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M18.316 5.684H24v12.632h-5.684V5.684zM5.684 24v-5.684h12.632V24H5.684zM18.316 5.684V0H5.684v5.684h12.632zM5.684 18.316H0V5.684h5.684v12.632zM7.895 14.947l1.5-1.263c.5-.421.868-.789.868-1.342 0-.71-.553-1.237-1.368-1.237-.658 0-1.132.316-1.5.816l-1.21-.816c.553-.816 1.395-1.395 2.763-1.395 1.605 0 2.763.947 2.763 2.316 0 .947-.5 1.658-1.289 2.316l-.921.763h2.289v1.421H7.895v-1.579zm6.658-3.684l-1.132.816-.71-1.079 2.184-1.579h1.289v8.5h-1.631v-6.658z"></path>
-                                </svg>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-calendar-plus-icon lucide-calendar-plus w-4 h-4"><path d="M16 19h6"/><path d="M16 2v4"/><path d="M19 16v6"/><path d="M21 12.598V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8.5"/><path d="M3 10h18"/><path d="M8 2v4"/></svg>
                             </a>
                         </div>
                     </div>

--- a/resources/views/filament/pages/components/calendar-token-manager.blade.php
+++ b/resources/views/filament/pages/components/calendar-token-manager.blade.php
@@ -1,4 +1,61 @@
 <div class="space-y-4">
+    <!-- Public calendar feeds -->
+    <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
+        <div class="flex items-center gap-2 mb-3">
+            <svg class="w-5 h-5 text-success-600 dark:text-success-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"></path>
+            </svg>
+            <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Veřejné kalendáře
+            </span>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Veřejné iCal feedy jsou dostupné bez přihlášení. Přidejte je do Google Calendar, Apple Calendar nebo jiné aplikace.
+        </p>
+
+        <div class="space-y-3">
+            <div>
+                <label class="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                    Závody (races)
+                </label>
+                <div class="flex gap-2">
+                    <div class="flex-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-2 font-mono text-xs break-all">
+                        {{ url('/api/feed/kalendar/zavody/all/') }}
+                    </div>
+                    <button
+                        type="button"
+                        onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/zavody/all/') }}'); $wire.call('copyCalendarUrl')"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            <div>
+                <label class="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                    Tréninky (trainings)
+                </label>
+                <div class="flex gap-2">
+                    <div class="flex-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-2 font-mono text-xs break-all">
+                        {{ url('/api/feed/kalendar/treninky/all/') }}
+                    </div>
+                    <button
+                        type="button"
+                        onclick="navigator.clipboard.writeText('{{ url('/api/feed/kalendar/treninky/all/') }}'); $wire.call('copyCalendarUrl')"
+                        class="flex-shrink-0 px-3 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg transition-colors"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     @if($this->has_calendar_token)
         <div class="space-y-3">
             <div class="bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-lg p-4">

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,12 @@ Route::get('/feed/kalendar/zavody/all/', [CalendarController::class, 'raceCalend
 Route::get('/feed/kalendar/treninky/all/', [CalendarController::class, 'trainingCalendar'])
     ->middleware('throttle:30,1');
 
+Route::get('/feed/kalendar/zavody/me/{token}', [CalendarController::class, 'personalRaceCalendar'])
+    ->middleware('throttle:30,1');
+
+Route::get('/feed/kalendar/treninky/me/{token}', [CalendarController::class, 'personalTrainingCalendar'])
+    ->middleware('throttle:30,1');
+
 // User API protected by x-apikey and member role
 Route::prefix('v1/user')->middleware([
     'apikey',

--- a/tests/Feature/Filament/CalendarTokenSettingsTest.php
+++ b/tests/Feature/Filament/CalendarTokenSettingsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\UserMailNotification;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = actingAsSuperAdmin();
+});
+
+test('unauthenticated user is redirected from user settings', function () {
+    Auth::logout();
+
+    $this->get('/admin/user-settings')
+        ->assertRedirect();
+});
+
+test('authenticated user can access user settings page', function () {
+    Livewire::test(UserMailNotification::class)
+        ->assertStatus(200);
+});
+
+test('user without token has has_calendar_token set to false', function () {
+    expect($this->user->calendar_token)->toBeNull();
+
+    Livewire::test(UserMailNotification::class)
+        ->assertSet('has_calendar_token', false);
+});
+
+test('generate calendar token stores hash in database', function () {
+    Livewire::test(UserMailNotification::class)
+        ->call('generateCalendarToken')
+        ->assertSet('has_calendar_token', true);
+
+    expect($this->user->fresh()->calendar_token)->not->toBeNull();
+});
+
+test('regenerate calendar token changes hash in database', function () {
+    Livewire::test(UserMailNotification::class)
+        ->call('generateCalendarToken');
+
+    $originalHash = $this->user->fresh()->calendar_token;
+
+    Livewire::test(UserMailNotification::class)
+        ->call('regenerateCalendarToken')
+        ->assertSet('has_calendar_token', true);
+
+    $newHash = $this->user->fresh()->calendar_token;
+
+    expect($newHash)->not->toBeNull()
+        ->and($newHash)->not->toBe($originalHash);
+});
+
+test('revoke calendar token removes hash from database', function () {
+    Livewire::test(UserMailNotification::class)
+        ->call('generateCalendarToken');
+
+    expect($this->user->fresh()->calendar_token)->not->toBeNull();
+
+    Livewire::test(UserMailNotification::class)
+        ->call('revokeCalendarToken')
+        ->assertSet('has_calendar_token', false)
+        ->assertSet('calendar_token', null);
+
+    expect($this->user->fresh()->calendar_token)->toBeNull();
+});
+
+test('user with existing token sees calendar_token set on fresh page load', function () {
+    $this->user->calendar_token = bin2hex(random_bytes(32));
+    $this->user->save();
+
+    Livewire::test(UserMailNotification::class)
+        ->assertSet('has_calendar_token', true)
+        ->assertSet('calendar_token', $this->user->calendar_token);
+});

--- a/tests/Feature/Ical/PersonalFeedTest.php
+++ b/tests/Feature/Ical/PersonalFeedTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\EntryStatus;
+use App\Enums\SportEventType;
+use App\Models\SportClassDefinition;
+use App\Models\SportEvent;
+use App\Models\SportList;
+use App\Models\User;
+use App\Models\UserEntry;
+use App\Models\UserRaceProfile;
+use App\Services\CalendarTokenService;
+
+beforeEach(function () {
+    $this->service = new CalendarTokenService();
+    $this->user = User::factory()->create(['active' => true]);
+    $this->token = $this->service->generate($this->user);
+});
+
+test('valid token returns 200 with ical content for race feed', function () {
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'text/calendar; charset=utf-8');
+    expect($response->getContent())->toContain('BEGIN:VCALENDAR');
+});
+
+test('invalid token returns 404 for race feed', function () {
+    $response = $this->get('/api/feed/kalendar/zavody/me/invalid-token-that-does-not-exist');
+
+    $response->assertStatus(404);
+});
+
+test('revoked token returns 404 for race feed', function () {
+    $this->service->revoke($this->user);
+
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    $response->assertStatus(404);
+});
+
+test('race feed has correct content-disposition header', function () {
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    $response->assertHeader('Content-Disposition', 'attachment; filename="abm-moje-zavody.ics"');
+});
+
+test('race feed has correct cache-control header', function () {
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    $cacheControl = $response->headers->get('Cache-Control');
+    expect($cacheControl)
+        ->toContain('no-cache')
+        ->toContain('no-store')
+        ->toContain('must-revalidate');
+});
+
+test('valid token returns 200 with ical content for training feed', function () {
+    $response = $this->get("/api/feed/kalendar/treninky/me/{$this->token}");
+
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'text/calendar; charset=utf-8');
+    expect($response->getContent())->toContain('BEGIN:VCALENDAR');
+});
+
+test('invalid token returns 404 for training feed', function () {
+    $response = $this->get('/api/feed/kalendar/treninky/me/invalid-token-that-does-not-exist');
+
+    $response->assertStatus(404);
+});
+
+test('revoked token returns 404 for training feed', function () {
+    $this->service->revoke($this->user);
+
+    $response = $this->get("/api/feed/kalendar/treninky/me/{$this->token}");
+
+    $response->assertStatus(404);
+});
+
+test('training feed has correct content-disposition header', function () {
+    $response = $this->get("/api/feed/kalendar/treninky/me/{$this->token}");
+
+    $response->assertHeader('Content-Disposition', 'attachment; filename="abm-moje-treninky.ics"');
+});
+
+test('training feed has correct cache-control header', function () {
+    $response = $this->get("/api/feed/kalendar/treninky/me/{$this->token}");
+
+    $cacheControl = $response->headers->get('Cache-Control');
+    expect($cacheControl)
+        ->toContain('no-cache')
+        ->toContain('no-store')
+        ->toContain('must-revalidate');
+});
+
+test('empty calendar returns valid ics with no events', function () {
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    $response->assertStatus(200);
+    $content = $response->getContent();
+    expect($content)
+        ->toContain('BEGIN:VCALENDAR')
+        ->toContain('END:VCALENDAR')
+        ->not->toContain('BEGIN:VEVENT');
+});
+
+test('personal feed only contains events for the token owner', function () {
+    $sport = SportList::create(['short_name' => 'OB']);
+
+    $sportEvent = SportEvent::factory()->create([
+        'event_type' => SportEventType::Race,
+        'cancelled' => false,
+        'date' => now()->addMonth(),
+        'sport_id' => $sport->id,
+        'discipline_id' => null,
+    ]);
+
+    $classDefinition = SportClassDefinition::create([
+        'sport_id' => $sportEvent->sport_id,
+        'age_from' => 18,
+        'age_to' => 99,
+        'name' => 'H21',
+    ]);
+
+    $profileA = UserRaceProfile::create([
+        'user_id' => $this->user->id,
+        'first_name' => 'User',
+        'last_name' => 'A',
+        'reg_number' => 'ABM0001',
+        'gender' => 'M',
+    ]);
+
+    UserEntry::create([
+        'sport_event_id' => $sportEvent->id,
+        'class_definition_id' => $classDefinition->id,
+        'user_race_profile_id' => $profileA->id,
+        'entry_status' => EntryStatus::Create,
+    ]);
+
+    $userB = User::factory()->create(['active' => true]);
+    $tokenB = $this->service->generate($userB);
+
+    $sportEventB = SportEvent::factory()->create([
+        'event_type' => SportEventType::Race,
+        'cancelled' => false,
+        'date' => now()->addMonths(2),
+        'name' => 'Event Only For User B',
+        'sport_id' => $sport->id,
+        'discipline_id' => null,
+    ]);
+
+    $profileB = UserRaceProfile::create([
+        'user_id' => $userB->id,
+        'first_name' => 'User',
+        'last_name' => 'B',
+        'reg_number' => 'ABM0002',
+        'gender' => 'F',
+    ]);
+
+    UserEntry::create([
+        'sport_event_id' => $sportEventB->id,
+        'class_definition_id' => $classDefinition->id,
+        'user_race_profile_id' => $profileB->id,
+        'entry_status' => EntryStatus::Create,
+    ]);
+
+    $responseA = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+    $contentA = $responseA->getContent();
+
+    expect($contentA)
+        ->toContain($sportEvent->name)
+        ->not->toContain('Event Only For User B');
+
+    $responseB = $this->get("/api/feed/kalendar/zavody/me/{$tokenB}");
+    $contentB = $responseB->getContent();
+
+    expect($contentB)
+        ->toContain('Event Only For User B')
+        ->not->toContain($sportEvent->name);
+});
+
+test('race feed includes events where user has entries', function () {
+    $sport = SportList::create(['short_name' => 'OB']);
+    $sportEvent = SportEvent::factory()->create([
+        'event_type' => SportEventType::Race,
+        'cancelled' => false,
+        'date' => now()->addMonth(),
+        'name' => 'Test Race Event',
+        'sport_id' => $sport->id,
+        'discipline_id' => null,
+    ]);
+
+    $classDefinition = SportClassDefinition::create([
+        'sport_id' => $sportEvent->sport_id,
+        'age_from' => 18,
+        'age_to' => 99,
+        'name' => 'H21',
+    ]);
+
+    $profile = UserRaceProfile::create([
+        'user_id' => $this->user->id,
+        'first_name' => 'Test',
+        'last_name' => 'Runner',
+        'reg_number' => 'ABM9999',
+        'gender' => 'M',
+    ]);
+
+    UserEntry::create([
+        'sport_event_id' => $sportEvent->id,
+        'class_definition_id' => $classDefinition->id,
+        'user_race_profile_id' => $profile->id,
+        'entry_status' => EntryStatus::Create,
+    ]);
+
+    $response = $this->get("/api/feed/kalendar/zavody/me/{$this->token}");
+
+    expect($response->getContent())
+        ->toContain('BEGIN:VEVENT')
+        ->toContain('Test Race Event');
+});


### PR DESCRIPTION
## Summary

- Add personal iCal feeds (races + trainings) scoped to user's entries, authenticated via opaque calendar tokens
- Add Kalendář tab to user settings page with token management (generate/regenerate/revoke) and public + personal feed URLs with webcal:// and Google Calendar subscribe buttons
- Include rate-limited API endpoints (`/feed/kalendar/{zavody,treninky}/me/{token}`) and full test coverage (settings UI + feed endpoints)

## Token implementation note

Calendar token uses the same approach as the existing API key — plaintext opaque token stored directly in the database. This is acceptable here since the feed is read-only access to the user's own events (which are already in the DB), but both tokens should be refactored to store hashed values with a one-time plaintext reveal on generation (similar to Laravel Sanctum's approach). Tracked for future improvement.

## Changes

| Area | What |
|---|---|
| **Migration** | `calendar_token` (char 64, nullable, unique) on `users` |
| **CalendarTokenService** | Generate, validate, revoke, regenerate opaque tokens |
| **IcalService** | `getPersonalRaceCalendar()` / `getPersonalTrainingCalendar()` — filters events by user's entries (non-cancelled) |
| **CalendarController** | Two new endpoints with token validation, 404 on invalid token |
| **Routes** | `GET /api/feed/kalendar/{zavody,treninky}/me/{token}` with `throttle:30,1` |
| **UserMailNotification** | New Kalendář tab, Livewire actions for token lifecycle |
| **Blade** | `calendar-token-manager.blade.php` — public feed URLs + personal feed section with copy/webcal/Google buttons |
| **Tests** | `CalendarTokenSettingsTest` (7 tests) + `PersonalFeedTest` (11 tests) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal calendar feeds for races and trainings accessible via secure per-user tokens.
  * Calendar token management in user settings: generate, regenerate, revoke, and copy feed URLs (including webcal/google links).
  * UI tab added for calendar feed/token management and direct copy/share controls.
  * Database now stores a unique nullable calendar token per user.

* **Tests**
  * Added tests covering token lifecycle and personal feed endpoints, headers, and scoped event contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->