### PR TITLE
fix(widget): add white background to QR payment code for dark theme

### DIFF
--- a/resources/views/filament/pages/widgets/user-credit-balance.blade.php
+++ b/resources/views/filament/pages/widgets/user-credit-balance.blade.php
@@ -17,14 +17,17 @@
 
                         <div>
                             {!!
-                                QrCode::size(120)->generate('SPD*1.0*RN:'
-                                . config('site-config.club.abbr')
-                                . '*ACC:'
-                                . config('site-config.club.iban')
-                                . '*CC:CZK*X-VS:'
-                                . config('site-config.club.extra_membership_fees_prefix')
-                                . Auth::user()->payer_variable_symbol
-                                . '*MSG:MIMORADNY CLENSKY VKLAD')
+                                QrCode::size(120)
+                                    ->backgroundColor(255, 255, 255)
+                                    ->margin(1)
+                                    ->generate('SPD*1.0*RN:'
+                                    . config('site-config.club.abbr')
+                                    . '*ACC:'
+                                    . config('site-config.club.iban')
+                                    . '*CC:CZK*X-VS:'
+                                    . config('site-config.club.extra_membership_fees_prefix')
+                                    . Auth::user()->payer_variable_symbol
+                                    . '*MSG:MIMORADNY CLENSKY VKLAD')
                             !!}
                         </div>
                         @endif


### PR DESCRIPTION
## Summary
- QR payment code in user credit balance widget had transparent SVG background — unreadable on dark theme
- Added `->backgroundColor(255, 255, 255)->margin(1)` to QrCode generator chain
- White background ensures readability on any color scheme, `margin(1)` is ISO 18004 quiet zone

## Changes
- `resources/views/filament/pages/widgets/user-credit-balance.blade.php` — added `backgroundColor` and `margin` methods to QrCode chain