### PR TITLE
fix(ical): improve LOCATION and add URL property to calendar feed

### DIFF
--- a/app/Services/IcalService.php
+++ b/app/Services/IcalService.php
@@ -94,9 +94,12 @@ final class IcalService
                 ->createdAt($sportEvent->date)
                 ->startsAt($dateFrom)
                 ->endsAt($dateEnd)
-                ->addressName($sportEvent->place ?? 'N/A')
-                ->coordinates((float) $sportEvent->gps_lat, (float) $sportEvent->gps_lon)
+                ->address($sportEvent->place ?? 'N/A')
                 ->classification(Classification::public());
+
+            if ($sportEvent->gps_lat !== null && $sportEvent->gps_lon !== null) {
+                $event->coordinates((float) $sportEvent->gps_lat, (float) $sportEvent->gps_lon);
+            }
 
             if ($fullDay) {
                 $event->fullDay();

--- a/app/Services/IcalService.php
+++ b/app/Services/IcalService.php
@@ -95,7 +95,8 @@ final class IcalService
                 ->startsAt($dateFrom)
                 ->endsAt($dateEnd)
                 ->address($sportEvent->place ?? 'N/A')
-                ->classification(Classification::public());
+                ->classification(Classification::public())
+                ->url(route('filament.admin.resources.sport-events.entry', ['record' => $sportEvent->id]));
 
             if ($sportEvent->gps_lat !== null && $sportEvent->gps_lon !== null) {
                 $event->coordinates((float) $sportEvent->gps_lat, (float) $sportEvent->gps_lon);

--- a/tests/Unit/IcalServiceTest.php
+++ b/tests/Unit/IcalServiceTest.php
@@ -36,7 +36,7 @@ test('address method is called instead of addressName to emit LOCATION property'
     expect($found)->toBeTrue();
 });
 
-test('null coordinates are handled safely without producing GEO property', function () {
+test('null coordinates do not produce GEO property in iCal output', function () {
     DB::statement('SET FOREIGN_KEY_CHECKS=0');
 
     SportEvent::factory()->create([
@@ -54,19 +54,14 @@ test('null coordinates are handled safely without producing GEO property', funct
     $events = $service->getEvents(SportEventType::Training);
 
     expect($events)->not->toBeEmpty();
-    
-    $allEventsValid = true;
+
     foreach ($events as $event) {
-        $output = $event->toString();
-        if ($output === '' || empty($output)) {
-            $allEventsValid = false;
-            break;
-        }
+        expect($event->toString())->not->toContain('GEO:0;0');
+        expect($event->toString())->not->toContain('GEO:0.0;0.0');
     }
-    expect($allEventsValid)->toBeTrue();
 });
 
-test('coordinates method is called when coordinates are not null', function () {
+test('real coordinates produce GEO property in iCal output', function () {
     DB::statement('SET FOREIGN_KEY_CHECKS=0');
 
     SportEvent::factory()->create([
@@ -81,8 +76,16 @@ test('coordinates method is called when coordinates are not null', function () {
     DB::statement('SET FOREIGN_KEY_CHECKS=1');
 
     $service = new IcalService();
-    
-    expect(function () use ($service) {
-        $service->getEvents(SportEventType::Race);
-    })->not->toThrow(Exception::class);
+    $events = $service->getEvents(SportEventType::Race);
+
+    expect($events)->not->toBeEmpty();
+
+    $found = false;
+    foreach ($events as $event) {
+        if (str_contains($event->toString(), 'GEO:')) {
+            $found = true;
+            break;
+        }
+    }
+    expect($found)->toBeTrue();
 });

--- a/tests/Unit/IcalServiceTest.php
+++ b/tests/Unit/IcalServiceTest.php
@@ -89,3 +89,30 @@ test('real coordinates produce GEO property in iCal output', function () {
     }
     expect($found)->toBeTrue();
 });
+
+test('event includes URL property linking to event detail page', function () {
+    DB::statement('SET FOREIGN_KEY_CHECKS=0');
+
+    $sportEvent = SportEvent::factory()->create([
+        'event_type' => SportEventType::Race,
+        'date' => Carbon::now()->addDay(),
+        'cancelled' => false,
+        'discipline_id' => null,
+    ]);
+
+    DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+    $service = new IcalService();
+    $events = $service->getEvents(SportEventType::Race);
+
+    expect($events)->not->toBeEmpty();
+
+    $found = false;
+    foreach ($events as $event) {
+        if (str_contains($event->toString(), '/admin/sport-events/')) {
+            $found = true;
+            break;
+        }
+    }
+    expect($found)->toBeTrue();
+});

--- a/tests/Unit/IcalServiceTest.php
+++ b/tests/Unit/IcalServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SportEventType;
+use App\Models\SportEvent;
+use App\Services\IcalService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+test('address method is called instead of addressName to emit LOCATION property', function () {
+    DB::statement('SET FOREIGN_KEY_CHECKS=0');
+
+    SportEvent::factory()->create([
+        'place' => 'TestPlace',
+        'event_type' => SportEventType::Race,
+        'date' => Carbon::now()->addDay(),
+        'cancelled' => false,
+        'discipline_id' => null,
+    ]);
+
+    DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+    $service = new IcalService();
+    $events = $service->getEvents(SportEventType::Race);
+
+    expect($events)->not->toBeEmpty();
+
+    $found = false;
+    foreach ($events as $event) {
+        if (str_contains($event->toString(), 'LOCATION:TestPlace')) {
+            $found = true;
+            break;
+        }
+    }
+    expect($found)->toBeTrue();
+});
+
+test('null coordinates are handled safely without producing GEO property', function () {
+    DB::statement('SET FOREIGN_KEY_CHECKS=0');
+
+    SportEvent::factory()->create([
+        'gps_lat' => null,
+        'gps_lon' => null,
+        'event_type' => SportEventType::Training,
+        'date' => Carbon::now()->addDay(),
+        'cancelled' => false,
+        'discipline_id' => null,
+    ]);
+
+    DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+    $service = new IcalService();
+    $events = $service->getEvents(SportEventType::Training);
+
+    expect($events)->not->toBeEmpty();
+    
+    $allEventsValid = true;
+    foreach ($events as $event) {
+        $output = $event->toString();
+        if ($output === '' || empty($output)) {
+            $allEventsValid = false;
+            break;
+        }
+    }
+    expect($allEventsValid)->toBeTrue();
+});
+
+test('coordinates method is called when coordinates are not null', function () {
+    DB::statement('SET FOREIGN_KEY_CHECKS=0');
+
+    SportEvent::factory()->create([
+        'gps_lat' => '49.1952',
+        'gps_lon' => '16.6068',
+        'event_type' => SportEventType::Race,
+        'date' => Carbon::now()->addDay(),
+        'cancelled' => false,
+        'discipline_id' => null,
+    ]);
+
+    DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+    $service = new IcalService();
+    
+    expect(function () use ($service) {
+        $service->getEvents(SportEventType::Race);
+    })->not->toThrow(Exception::class);
+});


### PR DESCRIPTION
## Summary
- Fix iCal feed to emit proper `LOCATION` property (was using `addressName` which produces `X-ADDRESS` instead of `LOCATION`)
- Fix `GEO:0;0` output for events without coordinates — now omits `GEO` entirely when lat/lon are null
- Add `URL` property to every event linking to the admin entry page (`/admin/sport-events/{id}/entry`)
## Details
- Switched from Spatie's `addressName()` to `address()` which correctly outputs RFC 5545 `LOCATION:` property
- Added conditional GEO — coordinates are only set when both `gps_lat` and `gps_lon` are non-null
- URL points to admin entry page instead of frontend `/akce/` route, since the frontend page may not be enabled on all instances
- 4 unit tests covering LOCATION, GEO (null + real), and URL properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iCal event exports now include direct URLs to event details.

* **Bug Fixes**
  * Fixed GPS coordinate handling in iCal exports to properly skip coordinates when location data is unavailable.
  * Corrected location field mapping in iCal event exports.

* **Tests**
  * Added unit tests validating iCal event generation and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->